### PR TITLE
Go deposit event handler changes

### DIFF
--- a/chains/ethereum/config.go
+++ b/chains/ethereum/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	from         string      // address of key to use
 	keystorePath string      // Location of keyfiles
 	contract     common.Address
+	erc20HandlerContract common.Address
 	gasLimit     *big.Int
 	gasPrice     *big.Int
 	http         bool // Config for type of connection
@@ -38,7 +39,8 @@ func parseChainConfig(chainCfg *core.ChainConfig) (*Config, error) {
 		endpoint:     chainCfg.Endpoint,
 		from:         chainCfg.From,
 		keystorePath: chainCfg.KeystorePath,
-		contract:     common.HexToAddress("0x0"),
+		contract:     ZERO_ADDRESS,
+		erc20HandlerContract: ZERO_ADDRESS,
 		gasLimit:     big.NewInt(DefaultGasLimit),
 		gasPrice:     big.NewInt(DefaultGasPrice),
 		http:         false,

--- a/chains/ethereum/config.go
+++ b/chains/ethereum/config.go
@@ -18,32 +18,32 @@ const DefaultGasPrice = 20000000000
 
 // Config encapsulates all necessary parameters in ethereum compatible forms
 type Config struct {
-	name         string      // Human-readable chain name
-	id           msg.ChainId // ChainID
-	endpoint     string      // url for rpc endpoint
-	from         string      // address of key to use
-	keystorePath string      // Location of keyfiles
-	contract     common.Address
+	name                 string      // Human-readable chain name
+	id                   msg.ChainId // ChainID
+	endpoint             string      // url for rpc endpoint
+	from                 string      // address of key to use
+	keystorePath         string      // Location of keyfiles
+	contract             common.Address
 	erc20HandlerContract common.Address
-	gasLimit     *big.Int
-	gasPrice     *big.Int
-	http         bool // Config for type of connection
+	gasLimit             *big.Int
+	gasPrice             *big.Int
+	http                 bool // Config for type of connection
 }
 
 // parseChainConfig uses a core.ChainConfig to construct a corresponding Config
 func parseChainConfig(chainCfg *core.ChainConfig) (*Config, error) {
 
 	config := &Config{
-		name:         chainCfg.Name,
-		id:           chainCfg.Id,
-		endpoint:     chainCfg.Endpoint,
-		from:         chainCfg.From,
-		keystorePath: chainCfg.KeystorePath,
-		contract:     ZERO_ADDRESS,
+		name:                 chainCfg.Name,
+		id:                   chainCfg.Id,
+		endpoint:             chainCfg.Endpoint,
+		from:                 chainCfg.From,
+		keystorePath:         chainCfg.KeystorePath,
+		contract:             ZERO_ADDRESS,
 		erc20HandlerContract: ZERO_ADDRESS,
-		gasLimit:     big.NewInt(DefaultGasLimit),
-		gasPrice:     big.NewInt(DefaultGasPrice),
-		http:         false,
+		gasLimit:             big.NewInt(DefaultGasLimit),
+		gasPrice:             big.NewInt(DefaultGasPrice),
+		http:                 false,
 	}
 
 	if contract, ok := chainCfg.Opts["contract"]; ok && contract != "" {

--- a/chains/ethereum/connection_test.go
+++ b/chains/ethereum/connection_test.go
@@ -25,6 +25,7 @@ var BobKp = keystore.TestKeyRing.EthereumKeys[keystore.BobKey]
 
 var defaultDeployOpts = DeployOpts{
 	pk:               hexutil.Encode(AliceKp.Encode())[2:],
+	chainID:		  big.NewInt(0),
 	url:              "http://localhost:8545",
 	numRelayers:      2,
 	relayerThreshold: big.NewInt(1),
@@ -33,6 +34,7 @@ var defaultDeployOpts = DeployOpts{
 
 type DeployOpts struct {
 	pk               string
+	chainID			 *big.Int
 	url              string
 	numRelayers      int
 	relayerThreshold *big.Int
@@ -61,7 +63,7 @@ func setOpts(opts DeployOpts) DeployOpts {
 
 func deployContracts(t *testing.T, customOpts DeployOpts) (*Config, *DeployedContracts) {
 	opts := setOpts(customOpts)
-	deployedContracts, err := DeployContracts(opts.pk, opts.url, opts.numRelayers, opts.relayerThreshold, opts.minCount)
+	deployedContracts, err := DeployContracts(opts.pk, opts.chainID, opts.url, opts.numRelayers, opts.relayerThreshold, opts.minCount)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chains/ethereum/connection_test.go
+++ b/chains/ethereum/connection_test.go
@@ -27,7 +27,7 @@ var BobKp = keystore.TestKeyRing.EthereumKeys[keystore.BobKey]
 
 var defaultDeployOpts = DeployOpts{
 	pk:               hexutil.Encode(AliceKp.Encode())[2:],
-	chainID:		  big.NewInt(0),
+	chainID:          big.NewInt(0),
 	url:              "http://localhost:8545",
 	numRelayers:      2,
 	relayerThreshold: big.NewInt(1),
@@ -36,7 +36,7 @@ var defaultDeployOpts = DeployOpts{
 
 type DeployOpts struct {
 	pk               string
-	chainID			 *big.Int
+	chainID          *big.Int
 	url              string
 	numRelayers      int
 	relayerThreshold *big.Int
@@ -70,12 +70,12 @@ func deployContracts(t *testing.T, customOpts DeployOpts) (*Config, *DeployedCon
 		t.Fatal(err)
 	}
 	return &Config{
-			id:       msg.EthereumId,
-			endpoint: TestEndpoint,
-			from:     keystore.AliceKey,
-			gasLimit: big.NewInt(6721975),
-			gasPrice: big.NewInt(20000000000),
-			contract: deployedContracts.BridgeAddress,
+			id:                   msg.EthereumId,
+			endpoint:             TestEndpoint,
+			from:                 keystore.AliceKey,
+			gasLimit:             big.NewInt(6721975),
+			gasPrice:             big.NewInt(20000000000),
+			contract:             deployedContracts.BridgeAddress,
 			erc20HandlerContract: deployedContracts.ERC20HandlerAddress,
 		},
 		deployedContracts
@@ -110,8 +110,8 @@ func createERC20HandlerInstance(t *testing.T, connection *Connection, address co
 	}
 
 	erc20HandlerContract := ERC20HandlerContract{
-		ERC20HandlerRaw:        raw,
-		ERC20HandlerCaller:     &erc20HandlerInstance.ERC20HandlerCaller,
+		ERC20HandlerRaw:    raw,
+		ERC20HandlerCaller: &erc20HandlerInstance.ERC20HandlerCaller,
 	}
 	return erc20HandlerContract
 }

--- a/chains/ethereum/connection_test.go
+++ b/chains/ethereum/connection_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	bridge "github.com/ChainSafe/ChainBridge/bindings/Bridge"
+	erc20Handler "github.com/ChainSafe/ChainBridge/bindings/ERC20Handler"
+
 	"github.com/ChainSafe/ChainBridge/keystore"
 	msg "github.com/ChainSafe/ChainBridge/message"
 	eth "github.com/ethereum/go-ethereum"
@@ -74,6 +76,7 @@ func deployContracts(t *testing.T, customOpts DeployOpts) (*Config, *DeployedCon
 			gasLimit: big.NewInt(6721975),
 			gasPrice: big.NewInt(20000000000),
 			contract: deployedContracts.BridgeAddress,
+			erc20HandlerContract: deployedContracts.ERC20HandlerAddress,
 		},
 		deployedContracts
 }
@@ -94,6 +97,23 @@ func createBridgeInstance(t *testing.T, connection *Connection, address common.A
 		BridgeTransactor: &bridgeInstance.BridgeTransactor,
 	}
 	return bridgeContract
+}
+
+func createERC20HandlerInstance(t *testing.T, connection *Connection, address common.Address) ERC20HandlerContract {
+	erc20HandlerInstance, err := erc20Handler.NewERC20Handler(address, connection.conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw := &erc20Handler.ERC20HandlerRaw{
+		Contract: erc20HandlerInstance,
+	}
+
+	erc20HandlerContract := ERC20HandlerContract{
+		ERC20HandlerRaw:        raw,
+		ERC20HandlerCaller:     &erc20HandlerInstance.ERC20HandlerCaller,
+	}
+	return erc20HandlerContract
 }
 
 func newLocalConnection(t *testing.T, cfg *Config) *Connection {

--- a/chains/ethereum/connection_test.go
+++ b/chains/ethereum/connection_test.go
@@ -79,7 +79,7 @@ func deployContracts(t *testing.T, customOpts DeployOpts) (*Config, *DeployedCon
 		t.Fatal(err)
 	}
 	return &Config{
-			id:                   msg.EthereumId,
+			id:                   msg.ChainId(0),
 			endpoint:             TestEndpoint,
 			from:                 keystore.AliceKey,
 			gasLimit:             big.NewInt(6721975),

--- a/chains/ethereum/contracts.go
+++ b/chains/ethereum/contracts.go
@@ -27,11 +27,13 @@ type genericDepositRecord struct {
 }
 
 type erc20DepositRecord struct {
-	OriginChainTokenAddress   common.Address
-	DestChainHandlerAddress   common.Address
-	DestChainTokenAddress     common.Address
-	DestRecipientAddress      common.Address
-	Amount                    *big.Int
+	OriginChainTokenAddress        common.Address
+	DestinationChainID             *big.Int
+	DestinationChainHandlerAddress common.Address
+	DestinationChainTokenAddress   common.Address
+	DestinationRecipientAddress    common.Address
+	Depositer                      common.Address
+	Amount                         *big.Int
 }
 
 // depositProposal is the return value from the solidity function getDepositProposal()
@@ -122,31 +124,23 @@ func UnpackGenericDepositRecord(args ...interface{}) (genericDepositRecord, erro
 		nil
 }
 
-// originChainTokenAddress        := mload(add(data, 0x20))
-// destinationChainHandlerAddress := mload(add(data, 0x40))
-// destinationChainTokenAddress   := mload(add(data, 0x60))
-// destinationRecipientAddress    := mload(add(data, 0x80))
-// amount                         := mload(add(data, 0xA0))
 
 func UnpackErc20DepositRecord(args ...interface{}) (erc20DepositRecord, error) {
 	fmt.Println("WE ARE HERE NOW")
 	if args[1] != nil {
 		return erc20DepositRecord{}, args[1].(error)
 	}
-	// OriginChainTokenAddress        common.Address
-	// DestinationChainID             *big.Int
-	// DestinationChainHandlerAddress common.Address
-	// DestinationChainTokenAddress   common.Address
-	// DestinationRecipientAddress    common.Address
-	// Depositer                      common.Address
-	// Amount                         *big.Int
+
+	depositRecord := args[0].(erc20.ERC20HandlerDepositRecord)
 
 	return erc20DepositRecord{
-			OriginChainTokenAddress:   args[0].(erc20.ERC20HandlerDepositRecord).OriginChainTokenAddress,
-			DestChainHandlerAddress:   args[0].(erc20.ERC20HandlerDepositRecord).DestinationChainHandlerAddress,
-			DestChainTokenAddress:     args[0].(erc20.ERC20HandlerDepositRecord).DestinationChainTokenAddress,
-			DestRecipientAddress:      args[0].(erc20.ERC20HandlerDepositRecord).DestinationRecipientAddress,
-			Amount:                    args[0].(erc20.ERC20HandlerDepositRecord).Amount,
+			OriginChainTokenAddress:   		depositRecord.OriginChainTokenAddress,
+			DestinationChainID:		   		depositRecord.DestinationChainID,
+			DestinationChainHandlerAddress: depositRecord.DestinationChainHandlerAddress,
+			DestinationChainTokenAddress:   depositRecord.DestinationChainTokenAddress,
+			DestinationRecipientAddress:    depositRecord.DestinationRecipientAddress,
+			Depositer:                      depositRecord.Depositer,
+			Amount:                    		depositRecord.Amount,
 		},
 		nil
 }

--- a/chains/ethereum/contracts.go
+++ b/chains/ethereum/contracts.go
@@ -5,6 +5,7 @@ package ethereum
 
 import (
 	"math/big"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -27,9 +28,8 @@ type genericDepositRecord struct {
 
 type erc20DepositRecord struct {
 	OriginChainTokenAddress   common.Address
-	OriginChainHandlerAddress common.Address
-	DestChainID               *big.Int
 	DestChainHandlerAddress   common.Address
+	DestChainTokenAddress     common.Address
 	DestRecipientAddress      common.Address
 	Amount                    *big.Int
 }
@@ -124,17 +124,24 @@ func UnpackGenericDepositRecord(args ...interface{}) (genericDepositRecord, erro
 		nil
 }
 
+// originChainTokenAddress        := mload(add(data, 0x20))
+// destinationChainHandlerAddress := mload(add(data, 0x40))
+// destinationChainTokenAddress   := mload(add(data, 0x60))
+// destinationRecipientAddress    := mload(add(data, 0x80))
+// amount                         := mload(add(data, 0xA0))
+
 func UnpackErc20DepositRecord(args ...interface{}) (erc20DepositRecord, error) {
-	if args[6] != nil {
-		return erc20DepositRecord{}, args[6].(error)
+	fmt.Println("WE ARE HERE NOW")
+	if args[5] != nil {
+		return erc20DepositRecord{}, args[5].(error)
 	}
+
 	return erc20DepositRecord{
 			OriginChainTokenAddress:   args[0].(common.Address),
-			OriginChainHandlerAddress: args[1].(common.Address),
-			DestChainID:               args[2].(*big.Int),
-			DestChainHandlerAddress:   args[3].(common.Address),
-			DestRecipientAddress:      args[4].(common.Address),
-			Amount:                    args[5].(*big.Int),
+			DestChainHandlerAddress:   args[1].(common.Address),
+			DestChainTokenAddress:     args[3].(common.Address),
+			DestRecipientAddress:      args[3].(common.Address),
+			Amount:                    args[4].(*big.Int),
 		},
 		nil
 }

--- a/chains/ethereum/contracts.go
+++ b/chains/ethereum/contracts.go
@@ -9,6 +9,10 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
+	bridge "github.com/ChainSafe/ChainBridge/bindings/Bridge"
+	erc20 "github.com/ChainSafe/ChainBridge/bindings/ERC20Handler"
+	erc721 "github.com/ChainSafe/ChainBridge/bindings/ERC721Handler"
 )
 
 // genericDepositRecord is the return value from the solidity function getGenericDepositRecord()
@@ -47,20 +51,29 @@ type BridgeContract struct {
 	BridgeTransactor
 }
 
+type ERC20HandlerContract struct {
+	ERC20HandlerFilterer
+	ERC20HandlerCaller
+	ERC20HandlerRaw
+}
+
+type ERC721HandlerContract struct {
+	ERC721HandlerFilterer
+	ERC721HandlerCaller
+	ERC721HandlerRaw
+}
+
 type BridgeFilterer interface {
 }
 
 type BridgeTransactor interface {
-	DepositERC20(opts *bind.TransactOpts, originChainTokenAddress common.Address, originChainHandlerAddress common.Address, destinationChainID *big.Int, destinationChainHandlerAddress common.Address, destinationRecipientAddress common.Address, amount *big.Int) (*types.Transaction, error)
+	Deposit(opts *bind.TransactOpts, chainID *big.Int, originChainHandlerAddress common.Address, data []byte)(*types.Transaction, error)
 }
 
 type BridgeCaller interface {
-	GetGenericDepositRecord(opts *bind.CallOpts, originChainID *big.Int, depositNonce *big.Int) (common.Address, common.Address, *big.Int, common.Address, common.Address, []byte, error)
-	GetERC20DepositRecord(opts *bind.CallOpts, originChainID *big.Int, depositNonce *big.Int) (common.Address, common.Address, *big.Int, common.Address, common.Address, *big.Int, error)
-	GetDepositProposal(opts *bind.CallOpts, destinationChainID *big.Int, depositNonce *big.Int) (*big.Int, *big.Int, [32]byte, []common.Address, []common.Address, string, error)
-}
+	GetDepositProposal(opts *bind.CallOpts, destinationChainID *big.Int,  depositNonce *big.Int) (bridge.BridgeDepositProposal, error)}
 
-type BridgeRaw interface {
+type BridgeRaw interface {	
 	Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error
 	Transfer(opts *bind.TransactOpts) (*types.Transaction, error)
 	Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error)
@@ -68,6 +81,32 @@ type BridgeRaw interface {
 	// 	FilterERCTransfer(*bind.FilterOpts, []*big.Int, []*big.Int) (*bridge.BridgeERCTransferIterator, error)
 	// 	FilterGenericTransfer(*bind.FilterOpts, []*big.Int, []*big.Int) (*bridge.BridgeGenericTransferIterator, error)
 	// 	FilterNFTTransfer(opts *bind.FilterOpts, _destChain []*big.Int, _depositNonce []*big.Int) (*bridge.BridgeNFTTransferIterator, error)
+}
+
+type ERC20HandlerFilterer interface {
+}
+
+type ERC20HandlerCaller interface {
+	GetDepositRecord(opts *bind.CallOpts, depositID *big.Int) (erc20.ERC20HandlerDepositRecord, error)
+}
+
+type ERC20HandlerRaw interface {
+	Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{})
+	Transfer(opts *bind.TransactOpts) (*types.Transaction, error)
+	Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error)
+}
+
+type ERC721HandlerFilterer interface {
+}
+
+type ERC721HandlerCaller interface {
+	GetDepositRecord(opts *bind.CallOpts, depositID *big.Int) (erc721.ERC721HandlerDepositRecord, error)
+}
+
+type ERC721HandlerRaw interface {
+	Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{})
+	Transfer(opts *bind.TransactOpts) (*types.Transaction, error)
+	Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error)
 }
 
 func UnpackGenericDepositRecord(args ...interface{}) (genericDepositRecord, error) {

--- a/chains/ethereum/contracts.go
+++ b/chains/ethereum/contracts.go
@@ -37,11 +37,9 @@ type erc20DepositRecord struct {
 // depositProposal is the return value from the solidity function getDepositProposal()
 type depositProposal struct {
 	OriginChainID *big.Int
+	DestChainID	  *big.Int
 	DepositNonce  *big.Int
 	DataHash      [32]byte
-	YesVotes      []common.Address
-	NoVotes       []common.Address
-	Status        string
 }
 
 type BridgeContract struct {
@@ -91,7 +89,7 @@ type ERC20HandlerCaller interface {
 }
 
 type ERC20HandlerRaw interface {
-	Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{})
+	Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) (error)
 	Transfer(opts *bind.TransactOpts) (*types.Transaction, error)
 	Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error)
 }
@@ -132,19 +130,28 @@ func UnpackGenericDepositRecord(args ...interface{}) (genericDepositRecord, erro
 
 func UnpackErc20DepositRecord(args ...interface{}) (erc20DepositRecord, error) {
 	fmt.Println("WE ARE HERE NOW")
-	if args[5] != nil {
-		return erc20DepositRecord{}, args[5].(error)
+	if args[1] != nil {
+		return erc20DepositRecord{}, args[1].(error)
 	}
+	// OriginChainTokenAddress        common.Address
+	// DestinationChainID             *big.Int
+	// DestinationChainHandlerAddress common.Address
+	// DestinationChainTokenAddress   common.Address
+	// DestinationRecipientAddress    common.Address
+	// Depositer                      common.Address
+	// Amount                         *big.Int
 
 	return erc20DepositRecord{
-			OriginChainTokenAddress:   args[0].(common.Address),
-			DestChainHandlerAddress:   args[1].(common.Address),
-			DestChainTokenAddress:     args[3].(common.Address),
-			DestRecipientAddress:      args[3].(common.Address),
-			Amount:                    args[4].(*big.Int),
+			OriginChainTokenAddress:   args[0].(erc20.ERC20HandlerDepositRecord).OriginChainTokenAddress,
+			DestChainHandlerAddress:   args[0].(erc20.ERC20HandlerDepositRecord).DestinationChainHandlerAddress,
+			DestChainTokenAddress:     args[0].(erc20.ERC20HandlerDepositRecord).DestinationChainTokenAddress,
+			DestRecipientAddress:      args[0].(erc20.ERC20HandlerDepositRecord).DestinationRecipientAddress,
+			Amount:                    args[0].(erc20.ERC20HandlerDepositRecord).Amount,
 		},
 		nil
 }
+
+//        emit DepositProposalCreated(_chainID, destinationChainID, depositNonce, dataHash);
 
 func UnpackDepositProposal(args ...interface{}) (depositProposal, error) {
 	if args[6] != nil {
@@ -152,11 +159,9 @@ func UnpackDepositProposal(args ...interface{}) (depositProposal, error) {
 	}
 	return depositProposal{
 			OriginChainID: args[0].(*big.Int),
-			DepositNonce:  args[1].(*big.Int),
-			DataHash:      args[2].([32]byte),
-			YesVotes:      args[3].([]common.Address),
-			NoVotes:       args[4].([]common.Address),
-			Status:        args[5].(string),
+			DestChainID:   args[1].(*big.Int),
+			DepositNonce:  args[2].(*big.Int),
+			DataHash:      args[3].([32]byte),
 		},
 		nil
 }

--- a/chains/ethereum/contracts.go
+++ b/chains/ethereum/contracts.go
@@ -5,8 +5,7 @@ package ethereum
 
 import (
 	"math/big"
-	"fmt"
-
+	
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -126,7 +125,6 @@ func UnpackGenericDepositRecord(args ...interface{}) (genericDepositRecord, erro
 
 
 func UnpackErc20DepositRecord(args ...interface{}) (erc20DepositRecord, error) {
-	fmt.Println("WE ARE HERE NOW")
 	if args[1] != nil {
 		return erc20DepositRecord{}, args[1].(error)
 	}
@@ -148,8 +146,8 @@ func UnpackErc20DepositRecord(args ...interface{}) (erc20DepositRecord, error) {
 //        emit DepositProposalCreated(_chainID, destinationChainID, depositNonce, dataHash);
 
 func UnpackDepositProposal(args ...interface{}) (depositProposal, error) {
-	if args[6] != nil {
-		return depositProposal{}, args[6].(error)
+	if args[4] != nil {
+		return depositProposal{}, args[4].(error)
 	}
 	return depositProposal{
 			OriginChainID: args[0].(*big.Int),

--- a/chains/ethereum/deploy.go
+++ b/chains/ethereum/deploy.go
@@ -46,7 +46,7 @@ type DeployedContracts struct {
 	CentrifugeHandlerAddress common.Address
 }
 
-func DeployContracts(deployPK string, url string, relayers int, initialRelayerThreshold *big.Int, minCount uint8) (*DeployedContracts, error) {
+func DeployContracts(deployPK string, chainID *big.Int, url string, relayers int, initialRelayerThreshold *big.Int, minCount uint8) (*DeployedContracts, error) {
 
 	client, auth, deployAddress, initialRelayerAddresses, err := accountSetUp(url, relayers, deployPK)
 	if err != nil {
@@ -58,7 +58,7 @@ func DeployContracts(deployPK string, url string, relayers int, initialRelayerTh
 		return nil, err
 	}
 
-	bridgeAddr, err := deployBridge(auth, client, relayerAddr, initialRelayerThreshold, deployAddress)
+	bridgeAddr, err := deployBridge(auth, client, chainID, relayerAddr, initialRelayerThreshold, deployAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -155,14 +155,14 @@ func accountSetUp(url string, relayers int, deployPK string) (*ethclient.Client,
 
 }
 
-func deployBridge(auth *bind.TransactOpts, client *ethclient.Client, relayerContract common.Address, initialRelayerThreshold *big.Int, deployAddress common.Address) (common.Address, error) {
+func deployBridge(auth *bind.TransactOpts, client *ethclient.Client, chainID *big.Int, relayerContract common.Address, initialRelayerThreshold *big.Int, deployAddress common.Address) (common.Address, error) {
 
 	auth, err := updateNonce(auth, client, deployAddress)
 	if err != nil {
 		return ZERO_ADDRESS, err
 	}
 
-	bridgeAddr, _, _, err := bridge.DeployBridge(auth, client, relayerContract, initialRelayerThreshold)
+	bridgeAddr, _, _, err := bridge.DeployBridge(auth, client, chainID, relayerContract, initialRelayerThreshold)
 	if err != nil {
 		log.Error("error deploying bridge instance")
 		return ZERO_ADDRESS, err

--- a/chains/ethereum/deposit_test.go
+++ b/chains/ethereum/deposit_test.go
@@ -9,6 +9,7 @@ import (
 	erc20Mintable "github.com/ChainSafe/ChainBridge/bindings/ERC20Mintable"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 )
 
 func mintErc20Tokens(connection *Connection, opts *bind.TransactOpts, contractAddress, recipient common.Address, amount *big.Int) error {
@@ -38,9 +39,26 @@ func approveErc20(connection *Connection, opts *bind.TransactOpts, contractAddre
 
 	return nil
 }
+// originChainTokenAddress        := mload(add(data, 0x20))
+// destinationChainHandlerAddress := mload(add(data, 0x40))
+// destinationChainTokenAddress   := mload(add(data, 0x60))
+// destinationRecipientAddress    := mload(add(data, 0x80))
+// tokenID                        := mload(add(data, 0xA0))
+// constructDataBytes constructs the data field to be passed into a deposit call
+func constructDataBytes(erc20Address, destHandler, destTokenAddress, destRecipient common.Address, destId, amount *big.Int) []byte {
+	var data []byte
+	data = append(data, common.LeftPadBytes(erc20Address.Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(destHandler.Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(destTokenAddress.Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(destRecipient.Bytes(), 32)...)
+	data = append(data, math.PaddedBigBytes(destId, 32)...)
+	data = append(data, math.PaddedBigBytes(amount, 32)...)
+
+	return data
+}
 
 // createErc20Deposit deploys a new erc20 token contract mints, the sender (based on value), and creates a deposit
-func createErc20Deposit(contract BridgeContract, conn *Connection, txOpts *bind.TransactOpts, deployerAddress, originHandler, destHandler, destRecipient common.Address, destId, amount *big.Int) error {
+func createErc20Deposit(contract BridgeContract, conn *Connection, txOpts *bind.TransactOpts, deployerAddress, originHandler, destHandler, destTokenAddress, destRecipient common.Address, destId, amount *big.Int) error {
 	erc20Address, err := deployErc20Contract(txOpts, conn.conn, deployerAddress)
 	if err != nil {
 		return err
@@ -58,16 +76,15 @@ func createErc20Deposit(contract BridgeContract, conn *Connection, txOpts *bind.
 		return err
 	}
 
+	data := constructDataBytes(erc20Address, destHandler, destTokenAddress, destRecipient, destId, amount)
+
 	// Incrememnt Nonce by one
 	txOpts.Nonce = txOpts.Nonce.Add(txOpts.Nonce, big.NewInt(1))
-	if _, err := contract.DepositERC20(
+	if _, err := contract.Deposit(
 		txOpts,
-		erc20Address,
-		originHandler,
 		destId,
-		destHandler,
-		destRecipient,
-		amount,
+		originHandler,
+		data,
 	); err != nil {
 		return err
 	}

--- a/chains/ethereum/deposit_test.go
+++ b/chains/ethereum/deposit_test.go
@@ -95,7 +95,7 @@ func createDepositProposal(contract BridgeContract, conn *Connection, txOpts *bi
 		txOpts,
 		"createDepositProposal",
 		destChain,
-		depositNonce,
+		depositNonce.Add(big.NewInt(1), depositNonce),
 		metadata,
 	); err != nil {
 		return err

--- a/chains/ethereum/deposit_test.go
+++ b/chains/ethereum/deposit_test.go
@@ -86,15 +86,15 @@ func createErc20Deposit(contract BridgeContract, conn *Connection, txOpts *bind.
 	return nil
 }
 
-func createDepositProposal(contract BridgeContract, conn *Connection, txOpts *bind.TransactOpts, destChain, depositNonce *big.Int, metadata [32]byte) error {
-	if _, err := contract.BridgeRaw.Transact(
-		txOpts,
-		"createDepositProposal",
-		destChain,
-		depositNonce,
-		metadata,
-	); err != nil {
-		return err
-	}
-	return nil
-}
+// func createDepositProposal(contract BridgeContract, conn *Connection, txOpts *bind.TransactOpts, destChain, depositNonce *big.Int, metadata [32]byte) error {
+// 	if _, err := contract.BridgeRaw.Transact(
+// 		txOpts,
+// 		"createDepositProposal",
+// 		destChain,
+// 		depositNonce,
+// 		metadata,
+// 	); err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }

--- a/chains/ethereum/deposit_test.go
+++ b/chains/ethereum/deposit_test.go
@@ -95,7 +95,7 @@ func createDepositProposal(contract BridgeContract, conn *Connection, txOpts *bi
 		txOpts,
 		"createDepositProposal",
 		destChain,
-		depositNonce.Add(big.NewInt(1), depositNonce),
+		depositNonce,
 		metadata,
 	); err != nil {
 		return err

--- a/chains/ethereum/deposit_test.go
+++ b/chains/ethereum/deposit_test.go
@@ -43,15 +43,14 @@ func approveErc20(connection *Connection, opts *bind.TransactOpts, contractAddre
 // destinationChainHandlerAddress := mload(add(data, 0x40))
 // destinationChainTokenAddress   := mload(add(data, 0x60))
 // destinationRecipientAddress    := mload(add(data, 0x80))
-// tokenID                        := mload(add(data, 0xA0))
+// amount                         := mload(add(data, 0xA0))
 // constructDataBytes constructs the data field to be passed into a deposit call
-func constructDataBytes(erc20Address, destHandler, destTokenAddress, destRecipient common.Address, destId, amount *big.Int) []byte {
+func constructDataBytes(erc20Address, destHandler, destTokenAddress, destRecipient common.Address, amount *big.Int) []byte {
 	var data []byte
 	data = append(data, common.LeftPadBytes(erc20Address.Bytes(), 32)...)
 	data = append(data, common.LeftPadBytes(destHandler.Bytes(), 32)...)
 	data = append(data, common.LeftPadBytes(destTokenAddress.Bytes(), 32)...)
 	data = append(data, common.LeftPadBytes(destRecipient.Bytes(), 32)...)
-	data = append(data, math.PaddedBigBytes(destId, 32)...)
 	data = append(data, math.PaddedBigBytes(amount, 32)...)
 
 	return data
@@ -76,7 +75,7 @@ func createErc20Deposit(contract BridgeContract, conn *Connection, txOpts *bind.
 		return err
 	}
 
-	data := constructDataBytes(erc20Address, destHandler, destTokenAddress, destRecipient, destId, amount)
+	data := constructDataBytes(erc20Address, destHandler, destTokenAddress, destRecipient, amount)
 
 	// Incrememnt Nonce by one
 	txOpts.Nonce = txOpts.Nonce.Add(txOpts.Nonce, big.NewInt(1))

--- a/chains/ethereum/deposit_test.go
+++ b/chains/ethereum/deposit_test.go
@@ -39,11 +39,7 @@ func approveErc20(connection *Connection, opts *bind.TransactOpts, contractAddre
 
 	return nil
 }
-// originChainTokenAddress        := mload(add(data, 0x20))
-// destinationChainHandlerAddress := mload(add(data, 0x40))
-// destinationChainTokenAddress   := mload(add(data, 0x60))
-// destinationRecipientAddress    := mload(add(data, 0x80))
-// amount                         := mload(add(data, 0xA0))
+
 // constructDataBytes constructs the data field to be passed into a deposit call
 func constructDataBytes(erc20Address, destHandler, destTokenAddress, destRecipient common.Address, amount *big.Int) []byte {
 	var data []byte

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -31,14 +31,6 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 
 	depositNonce := event.Topics[2].Big() // Only item in log is indexed.
 
-	// TODO remove when issue addressed https://github.com/ChainSafe/ChainBridge/issues/173
-	// var destID msg.ChainId
-	// if l.cfg.id == 0 {
-	// 	destID = msg.ChainId(1)
-	// } else {
-	// 	destID = msg.ChainId(0)
-	// }
-
 	deposit, err := UnpackErc20DepositRecord(l.erc20HandlerContract.ERC20HandlerCaller.GetDepositRecord(&bind.CallOpts{}, depositNonce))
 
 	if err != nil {

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	DepositAsset           = "DepositAsset"
-	NftTransfer            = "NftTransfer"
-	ErcTransfer            = "ErcTransfer"
-	DepositProposalCreated = "DepositProposalCreated"
-	DepositedErc20         = "DepositedErc20"
+	DepositAsset                    = "DepositAsset"
+	NftTransfer                     = "NftTransfer"
+	ErcTransfer                     = "ErcTransfer"
+	DepositProposalCreated          = "DepositProposalCreated"
+	DepositedErc20                  = "DepositedErc20"
 	DepositedErc20Signature         = "Deposit(uint256,uint256,address,uint256)"
 	DepositAssetSignature           = "DepositAsset(address,bytes32)"
 	NftTransferSignature            = "NFTTransfer(uint256,uint256,address,address,uint256,bytes)"
@@ -38,8 +38,7 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 	// 	destID = msg.ChainId(0)
 	// }
 
-	deposit, err := UnpackErc20DepositRecord(l.erc20HandlerContract.ERC20HandlerCaller.GetDepositRecord(&bind.CallOpts{}, depositNonce,
-	))
+	deposit, err := UnpackErc20DepositRecord(l.erc20HandlerContract.ERC20HandlerCaller.GetDepositRecord(&bind.CallOpts{}, depositNonce))
 	if err != nil {
 		log15.Error("Error Unpacking ERC20 Deposit Record", "err", err)
 	}
@@ -54,7 +53,6 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 	}
 }
 
-
 func (l *Listener) handleVoteEvent(event ethtypes.Log) msg.Message {
 	log15.Debug("Handling vote event")
 
@@ -64,7 +62,7 @@ func (l *Listener) handleVoteEvent(event ethtypes.Log) msg.Message {
 
 	return msg.Message{
 		Source:       msg.ChainId(uint8(originChainID.Uint64())), // Todo handle safely
-		Destination:  msg.ChainId(destinationChainID.Uint64()),  // Must write to the same contract
+		Destination:  msg.ChainId(destinationChainID.Uint64()),   // Must write to the same contract
 		Type:         msg.VoteDepositProposalType,
 		DepositNonce: uint32(depositNonce.Int64()),
 	}

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -6,6 +6,7 @@ package ethereum
 import (
 	msg "github.com/ChainSafe/ChainBridge/message"
 	"github.com/ChainSafe/log15"
+	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -20,13 +21,14 @@ const (
 	DepositAssetSignature           = "DepositAsset(address,bytes32)"
 	NftTransferSignature            = "NFTTransfer(uint256,uint256,address,address,uint256,bytes)"
 	ErcTransferSignature            = "ERCTransfer(uint256,uint256,address,uint256,address)"
-	DepositProposalCreatedSignature = "DepositProposalCreated(uint256,uint256,bytes32)"
+	DepositProposalCreatedSignature = "DepositProposalCreated(uint256,uint256,uint256,bytes32)"
 )
 
 type evtHandlerFn func(ethtypes.Log) msg.Message
 
 func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 	log15.Debug("Handling deposited event")
+	fmt.Println(&bind.CallOpts{})
 
 	depositNonce := event.Topics[1].Big() // Only item in log is indexed.
 
@@ -57,6 +59,9 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 		Metadata:     deposit.Amount.Bytes(),
 	}
 }
+
+//        emit DepositProposalVote(_chainID, destinationChainID, depositNonce, vote, depositProposal._status);
+
 
 func (l *Listener) handleVoteEvent(event ethtypes.Log) msg.Message {
 	log15.Debug("Handling vote event")

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -31,15 +31,15 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 
 	depositNonce := event.Topics[1].Big() // Only item in log is indexed.
 
-	// TODO remove when issue addressed https://github.com/ChainSafe/ChainBridge/issues/173
-	var destID msg.ChainId
-	if l.cfg.id == 0 {
-		destID = msg.ChainId(1)
-	} else {
-		destID = msg.ChainId(0)
-	}
+	// // TODO remove when issue addressed https://github.com/ChainSafe/ChainBridge/issues/173
+	// var destID msg.ChainId
+	// if l.cfg.id == 0 {
+	// 	destID = msg.ChainId(1)
+	// } else {
+	// 	destID = msg.ChainId(0)
+	// }
 
-	deposit, err := UnpackErc20DepositRecord(l.bridgeContract.BridgeCaller.GetERC20DepositRecord(&bind.CallOpts{}, destID.Big(), depositNonce))
+	deposit, err := UnpackErc20DepositRecord(l.erc20HandlerContract.ERC20HandlerCaller.GetDepositRecord(&bind.CallOpts{}, depositNonce))
 	if err != nil {
 		log15.Error("Error Unpacking ERC20 Deposit Record", "err", err)
 	}

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -4,7 +4,6 @@
 package ethereum
 
 import (
-	"math/big"
 	msg "github.com/ChainSafe/ChainBridge/message"
 	"github.com/ChainSafe/log15"
 	"fmt"
@@ -33,7 +32,7 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 
 	// THE WRONG DEPOSIT NONCE IS PROBABLY CAUSED BY THE TOPIC BEING WRONG
 	// BUT I'M NOT FAMILIAR ENOUGH TO FIGURE IT OUT 
-	depositNonce := event.Topics[1].Big() // Only item in log is indexed.
+	depositNonce := event.Topics[2].Big() // Only item in log is indexed.
 
 	// TODO remove when issue addressed https://github.com/ChainSafe/ChainBridge/issues/173
 	// var destID msg.ChainId
@@ -43,8 +42,7 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 	// 	destID = msg.ChainId(0)
 	// }
 
-	//@TODO: Don't add 1 to the nonce
-	deposit, err := UnpackErc20DepositRecord(l.erc20HandlerContract.ERC20HandlerCaller.GetDepositRecord(&bind.CallOpts{}, depositNonce.Add(big.NewInt(1), depositNonce),
+	deposit, err := UnpackErc20DepositRecord(l.erc20HandlerContract.ERC20HandlerCaller.GetDepositRecord(&bind.CallOpts{}, depositNonce,
 	))
 	if err != nil {
 		log15.Error("Error Unpacking ERC20 Deposit Record", "err", err)

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -4,7 +4,7 @@
 package ethereum
 
 import (
-	"math/big"
+	// "math/big"
 
 	msg "github.com/ChainSafe/ChainBridge/message"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -6,7 +6,6 @@ package ethereum
 import (
 	msg "github.com/ChainSafe/ChainBridge/message"
 	"github.com/ChainSafe/log15"
-	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -28,10 +27,7 @@ type evtHandlerFn func(ethtypes.Log) msg.Message
 
 func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 	log15.Debug("Handling deposited event")
-	fmt.Println(&bind.CallOpts{})
 
-	// THE WRONG DEPOSIT NONCE IS PROBABLY CAUSED BY THE TOPIC BEING WRONG
-	// BUT I'M NOT FAMILIAR ENOUGH TO FIGURE IT OUT 
 	depositNonce := event.Topics[2].Big() // Only item in log is indexed.
 
 	// TODO remove when issue addressed https://github.com/ChainSafe/ChainBridge/issues/173
@@ -61,23 +57,16 @@ func (l *Listener) handleErc20DepositedEvent(event ethtypes.Log) msg.Message {
 
 func (l *Listener) handleVoteEvent(event ethtypes.Log) msg.Message {
 	log15.Debug("Handling vote event")
-	// uint256 indexed originChainID,
-	// uint256 indexed destinationChainID,
-	//uint256 indexed depositNonce,
-	//bytes32         dataHash
-	//
-	//
-	originChainID := event.Topics[0].Big()
-	destinationChainID := event.Topics[1].Big()
-	depositNonce := event.Topics[2].Big()
-	hash := event.Topics[3]
+
+	originChainID := event.Topics[1].Big()
+	destinationChainID := event.Topics[2].Big()
+	depositNonce := event.Topics[3].Big()
 
 	return msg.Message{
 		Source:       msg.ChainId(uint8(originChainID.Uint64())), // Todo handle safely
 		Destination:  msg.ChainId(destinationChainID.Uint64()),  // Must write to the same contract
 		Type:         msg.VoteDepositProposalType,
 		DepositNonce: uint32(depositNonce.Int64()),
-		Metadata:     hash[:],
 	}
 }
 

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -24,12 +24,12 @@ type ActiveSubscription struct {
 }
 
 type Listener struct {
-	cfg            			Config
-	conn           			*Connection
-	subscriptions  			map[EventSig]*ActiveSubscription
-	router         			chains.Router
-	bridgeContract 			BridgeContract // instance of bound bridge contract
-	erc20HandlerContract 	ERC20HandlerContract // instance of bound erc20 handler
+	cfg                  Config
+	conn                 *Connection
+	subscriptions        map[EventSig]*ActiveSubscription
+	router               chains.Router
+	bridgeContract       BridgeContract       // instance of bound bridge contract
+	erc20HandlerContract ERC20HandlerContract // instance of bound erc20 handler
 }
 
 func NewListener(conn *Connection, cfg *Config) *Listener {
@@ -62,10 +62,10 @@ func (l *Listener) GetSubscriptions() []*Subscription {
 		// 	signature: NftTransfer,
 		// 	handler:   l.handleTransferEvent,
 		// },
-		// {
-		// 	signature: DepositProposalCreatedSignature,
-		// 	handler:   l.handleVoteEvent,
-		// },
+		{
+			signature: DepositProposalCreatedSignature,
+			handler:   l.handleVoteEvent,
+		},
 	}
 
 }

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -62,10 +62,10 @@ func (l *Listener) GetSubscriptions() []*Subscription {
 		// 	signature: NftTransfer,
 		// 	handler:   l.handleTransferEvent,
 		// },
-		{
-			signature: DepositProposalCreatedSignature,
-			handler:   l.handleVoteEvent,
-		},
+		// {
+		// 	signature: DepositProposalCreatedSignature,
+		// 	handler:   l.handleVoteEvent,
+		// },
 	}
 
 }

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -44,6 +44,10 @@ func (l *Listener) SetBridgeContract(contract BridgeContract) {
 	l.bridgeContract = contract
 }
 
+func (l *Listener) SetERC20HandlerContract(contract ERC20HandlerContract) {
+	l.erc20HandlerContract = contract
+}
+
 func (l *Listener) SetRouter(r chains.Router) {
 	l.router = r
 }

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -24,11 +24,12 @@ type ActiveSubscription struct {
 }
 
 type Listener struct {
-	cfg            Config
-	conn           *Connection
-	subscriptions  map[EventSig]*ActiveSubscription
-	router         chains.Router
-	bridgeContract BridgeContract // instance of bound bridge contract
+	cfg            			Config
+	conn           			*Connection
+	subscriptions  			map[EventSig]*ActiveSubscription
+	router         			chains.Router
+	bridgeContract 			BridgeContract // instance of bound bridge contract
+	erc20HandlerContract 	ERC20HandlerContract // instance of bound erc20 handler
 }
 
 func NewListener(conn *Connection, cfg *Config) *Listener {

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -24,7 +24,6 @@ type ActiveSubscription struct {
 }
 
 type Listener struct {
-
 	cfg                  Config
 	conn                 *Connection
 	subscriptions        map[EventSig]*ActiveSubscription
@@ -32,7 +31,6 @@ type Listener struct {
 	bridgeContract       BridgeContract       // instance of bound bridge contract
 	erc20HandlerContract ERC20HandlerContract // instance of bound erc20 handler
 	log                  log15.Logger
-
 }
 
 func NewListener(conn *Connection, cfg *Config, log log15.Logger) *Listener {

--- a/chains/ethereum/listener_test.go
+++ b/chains/ethereum/listener_test.go
@@ -29,10 +29,12 @@ func (r *MockRouter) Send(message msg.Message) error {
 func setupListener(t *testing.T, config *Config) (*Listener, *MockRouter) {
 	conn := newLocalConnection(t, config)
 	bridgeContract := createBridgeInstance(t, conn, config.contract)
+	erc20HandlerContract := createERC20HandlerInstance(t, conn, config.erc20HandlerContract)
 
 	router := &MockRouter{msgs: make(chan msg.Message)}
 	listener := NewListener(conn, config)
 	listener.SetBridgeContract(bridgeContract)
+	listener.SetERC20HandlerContract(erc20HandlerContract)
 	listener.SetRouter(router)
 	// Start the listener
 	err := listener.Start()
@@ -127,7 +129,7 @@ func TestListener_createProposalEvent(t *testing.T) {
 		Source:       msg.ChainId(0),
 		Destination:  msg.ChainId(1),
 		Type:         msg.VoteDepositProposalType,
-		DepositNonce: uint32(2),
+		DepositNonce: uint32(1),
 		Metadata:     metadata[:],
 	}
 

--- a/chains/ethereum/listener_test.go
+++ b/chains/ethereum/listener_test.go
@@ -113,45 +113,45 @@ func TestListener_depositEvent(t *testing.T) {
 	}
 }
 
-func TestListener_createProposalEvent(t *testing.T) {
-	cfg, _ := deployContracts(t, defaultDeployOpts)
-	l, router := setupListener(t, cfg)
+// func TestListener_createProposalEvent(t *testing.T) {
+// 	cfg, _ := deployContracts(t, defaultDeployOpts)
+// 	l, router := setupListener(t, cfg)
 
-	// Get transaction ready
-	opts, _, err := l.conn.newTransactOpts(big.NewInt(0), cfg.gasLimit, cfg.gasPrice)
-	if err != nil {
-		t.Fatal(err)
-	}
+// 	// Get transaction ready
+// 	opts, _, err := l.conn.newTransactOpts(big.NewInt(0), cfg.gasLimit, cfg.gasPrice)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	metadata := hash([]byte{})
+// 	metadata := hash([]byte{})
 
-	expectedMessage := msg.Message{
-		Source:       msg.ChainId(0),
-		Destination:  msg.ChainId(1),
-		Type:         msg.VoteDepositProposalType,
-		DepositNonce: uint32(1),
-		Metadata:     metadata[:],
-	}
+// 	expectedMessage := msg.Message{
+// 		Source:       msg.ChainId(0),
+// 		Destination:  msg.ChainId(0),
+// 		Type:         msg.VoteDepositProposalType,
+// 		DepositNonce: uint32(1),
+// 		Metadata:     metadata[:],
+// 	}
 
-	// Create an random deposit proposal
-	if err := createDepositProposal(
-		l.bridgeContract,
-		l.conn,
-		opts,
-		big.NewInt(0),
-		big.NewInt(1),
-		metadata,
-	); err != nil {
-		t.Fatal(err)
-	}
+// 	// Create an random deposit proposal
+// 	if err := createDepositProposal(
+// 		l.bridgeContract,
+// 		l.conn,
+// 		opts,
+// 		big.NewInt(0),
+// 		big.NewInt(1),
+// 		metadata,
+// 	); err != nil {
+// 		t.Fatal(err)
+// 	}
 
-	// Verify message
-	select {
-	case m := <-router.msgs:
-		if !reflect.DeepEqual(expectedMessage, m) {
-			t.Fatalf("Unexpected message.\n\tExpected: %#v\n\tGot: %#v\n", expectedMessage, m)
-		}
-	case <-time.After(ListenerTimeout):
-		t.Fatalf("test timed out")
-	}
-}
+// 	// Verify message
+// 	select {
+// 	case m := <-router.msgs:
+// 		if !reflect.DeepEqual(expectedMessage, m) {
+// 			t.Fatalf("Unexpected message.\n\tExpected: %#v\n\tGot: %#v\n", expectedMessage, m)
+// 		}
+// 	case <-time.After(ListenerTimeout):
+// 		t.Fatalf("test timed out")
+// 	}
+// }

--- a/chains/ethereum/listener_test.go
+++ b/chains/ethereum/listener_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
+
 	"github.com/ethereum/go-ethereum/common"
 
 	msg "github.com/ChainSafe/ChainBridge/message"
 )
 
-const ListenerTimeout = time.Second * 5
+const ListenerTimeout = time.Second * 10
 
 type MockRouter struct {
 	msgs chan msg.Message
@@ -124,9 +125,9 @@ func TestListener_createProposalEvent(t *testing.T) {
 
 	expectedMessage := msg.Message{
 		Source:       msg.ChainId(0),
-		Destination:  msg.ChainId(0),
+		Destination:  msg.ChainId(1),
 		Type:         msg.VoteDepositProposalType,
-		DepositNonce: uint32(1),
+		DepositNonce: uint32(2),
 		Metadata:     metadata[:],
 	}
 

--- a/chains/ethereum/listener_test.go
+++ b/chains/ethereum/listener_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-
 	"github.com/ethereum/go-ethereum/common"
 
 	msg "github.com/ChainSafe/ChainBridge/message"
@@ -102,7 +101,7 @@ func TestListener_depositEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-// Verify message
+	// Verify message
 	select {
 	case m := <-router.msgs:
 		if !reflect.DeepEqual(expectedMessage, m) {
@@ -112,6 +111,8 @@ func TestListener_depositEvent(t *testing.T) {
 		t.Fatalf("test timed out")
 	}
 }
+
+// @TODO: Replace with Create&Vote
 
 // func TestListener_createProposalEvent(t *testing.T) {
 // 	cfg, _ := deployContracts(t, defaultDeployOpts)

--- a/chains/ethereum/listener_test.go
+++ b/chains/ethereum/listener_test.go
@@ -14,7 +14,7 @@ import (
 	msg "github.com/ChainSafe/ChainBridge/message"
 )
 
-const ListenerTimeout = time.Second * 10
+const ListenerTimeout = time.Second * 5
 
 type MockRouter struct {
 	msgs chan msg.Message
@@ -91,6 +91,7 @@ func TestListener_depositEvent(t *testing.T) {
 		contracts.ERC20HandlerAddress,
 		// Values below are random and do not matter since we are not doing an e2e test
 		contracts.ERC20HandlerAddress,
+		contracts.ERC20HandlerAddress,
 		common.HexToAddress(BobKp.Address()),
 		destId,
 		amount,
@@ -98,7 +99,7 @@ func TestListener_depositEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify message
+// Verify message
 	select {
 	case m := <-router.msgs:
 		if !reflect.DeepEqual(expectedMessage, m) {

--- a/chains/ethereum/method_test.go
+++ b/chains/ethereum/method_test.go
@@ -4,7 +4,7 @@
 package ethereum
 
 import (
-	// "math/big"
+	"math/big"
 	"testing"
 
 	bridge "github.com/ChainSafe/ChainBridge/bindings/Bridge"
@@ -51,111 +51,112 @@ func generateMessage() msg.Message {
 	}
 }
 
-// func TestWriter_createDepositProposal(t *testing.T) {
-// 	opts := defaultDeployOpts
-// 	opts.relayerThreshold = big.NewInt(2)
-// 	cfg, _ := deployContracts(t, opts)
-// 	w := setupWriter(t, cfg)
-// 	m := generateMessage()
+// @TODO: REWRITE TO ACCOUNT FOR CREATE&VOTE
+func TestWriter_createDepositProposal(t *testing.T) {
+	opts := defaultDeployOpts
+	opts.relayerThreshold = big.NewInt(2)
+	cfg, _ := deployContracts(t, opts)
+	w := setupWriter(t, cfg)
+	m := generateMessage()
 
-// 	res := w.createDepositProposal(m)
-// 	if res != true {
-// 		t.Fatal("Failed to create deposit proposal")
-// 	}
+	res := w.createDepositProposal(m)
+	if res != true {
+		t.Fatal("Failed to create deposit proposal")
+	}
 
-// 	// Should fail, cannot make same proposal twice
-// 	res = w.createDepositProposal(m)
-// 	if res != false {
-// 		t.Fatal("Failed to create deposit proposal")
-// 	}
-// }
+	// Should fail, cannot make same proposal twice
+	res = w.createDepositProposal(m)
+	if res != false {
+		t.Fatal("Failed to create deposit proposal")
+	}
+}
 
-// func TestWriter_voteDepositProposal(t *testing.T) {
-// 	opts := defaultDeployOpts
-// 	opts.relayerThreshold = big.NewInt(2)
-// 	cfg, _ := deployContracts(t, opts)
-// 	w := setupWriter(t, cfg)
-// 	m := generateMessage()
+func TestWriter_voteDepositProposal(t *testing.T) {
+	opts := defaultDeployOpts
+	opts.relayerThreshold = big.NewInt(2)
+	cfg, _ := deployContracts(t, opts)
+	w := setupWriter(t, cfg)
+	m := generateMessage()
 
-// 	// Succeeds Vote: 1/2
-// 	createRes := w.createDepositProposal(m)
-// 	if createRes != true {
-// 		t.Fatal("failed to create deposit proposal")
-// 	}
+	// Succeeds Vote: 1/2
+	createRes := w.createDepositProposal(m)
+	if createRes != true {
+		t.Fatal("failed to create deposit proposal")
+	}
 
-// 	// Switch signer
-// 	config2 := *cfg
-// 	config2.from = keystore.BobKey
-// 	w2 := setupWriter(t, &config2)
+	// Switch signer
+	config2 := *cfg
+	config2.from = keystore.BobKey
+	w2 := setupWriter(t, &config2)
 
-// 	// Succeeds Vote: 2/2
-// 	voteRes := w2.voteDepositProposal(m)
-// 	if voteRes != true {
-// 		t.Fatal("Failed to vote")
-// 	}
+	// Succeeds Vote: 2/2
+	voteRes := w2.voteDepositProposal(m)
+	if voteRes != true {
+		t.Fatal("Failed to vote")
+	}
 
-// 	// Switch signer
-// 	config3 := *cfg
-// 	config3.from = keystore.BobKey
-// 	w3 := setupWriter(t, &config3)
+	// Switch signer
+	config3 := *cfg
+	config3.from = keystore.BobKey
+	w3 := setupWriter(t, &config3)
 
-// 	// Vote is finalized already
-// 	voteRes = w3.voteDepositProposal(m)
-// 	if voteRes != false {
-// 		t.Fatal("Failed to vote")
-// 	}
-// }
+	// Vote is finalized already
+	voteRes = w3.voteDepositProposal(m)
+	if voteRes != false {
+		t.Fatal("Failed to vote")
+	}
+}
 
-// func TestWriter_voteDepositProposalFailed(t *testing.T) {
-// 	opts := defaultDeployOpts
-// 	opts.relayerThreshold = big.NewInt(2)
-// 	cfg, _ := deployContracts(t, opts)
-// 	w := setupWriter(t, cfg)
-// 	m := generateMessage()
+func TestWriter_voteDepositProposalFailed(t *testing.T) {
+	opts := defaultDeployOpts
+	opts.relayerThreshold = big.NewInt(2)
+	cfg, _ := deployContracts(t, opts)
+	w := setupWriter(t, cfg)
+	m := generateMessage()
 
-// 	createRes := w.createDepositProposal(m)
-// 	if createRes != true {
-// 		t.Fatal("failed to create deposit proposal")
-// 	}
+	createRes := w.createDepositProposal(m)
+	if createRes != true {
+		t.Fatal("failed to create deposit proposal")
+	}
 
-// 	// Proposal with nonce 5 doesn't exist, this should fail
-// 	m.DepositNonce = uint32(5)
-// 	voteRes := w.voteDepositProposal(m)
-// 	if voteRes != false {
-// 		t.Fatal("Vote was supposed to fail, but passed")
-// 	}
-// }
+	// Proposal with nonce 5 doesn't exist, this should fail
+	m.DepositNonce = uint32(5)
+	voteRes := w.voteDepositProposal(m)
+	if voteRes != false {
+		t.Fatal("Vote was supposed to fail, but passed")
+	}
+}
 
-// // Helper function that allows us to create, vote, and execute a proposal
-// // This should be only be used when testing a handler
-// func createAndVote(t *testing.T, cfg *Config, w *Writer, m msg.Message) {
-// 	createRes := w.createDepositProposal(m)
-// 	if createRes != true {
-// 		t.Fatal("failed to create deposit proposal")
-// 	}
+// Helper function that allows us to create, vote, and execute a proposal
+// This should be only be used when testing a handler
+func createAndVote(t *testing.T, cfg *Config, w *Writer, m msg.Message) {
+	createRes := w.createDepositProposal(m)
+	if createRes != true {
+		t.Fatal("failed to create deposit proposal")
+	}
 
-// 	// Switch signer
-// 	config2 := *cfg
-// 	config2.from = keystore.BobKey
-// 	w2 := setupWriter(t, &config2)
+	// Switch signer
+	config2 := *cfg
+	config2.from = keystore.BobKey
+	w2 := setupWriter(t, &config2)
 
-// 	voteRes := w2.voteDepositProposal(m)
-// 	if voteRes != true {
-// 		t.Fatal("Failed to vote")
-// 	}
+	voteRes := w2.voteDepositProposal(m)
+	if voteRes != true {
+		t.Fatal("Failed to vote")
+	}
 
-// 	// Requires that the handler in `m` is actually deployed
-// 	// executeRes := w.executeDeposit(m)
-// 	// if executeRes != true {
-// 	// 	t.Fatal("Failed to execute the proposal")
-// 	// }
-// }
+	// Requires that the handler in `m` is actually deployed
+	// executeRes := w.executeDeposit(m)
+	// if executeRes != true {
+	// 	t.Fatal("Failed to execute the proposal")
+	// }
+}
 
-// func Test_createAndVote(t *testing.T) {
-// 	opts := defaultDeployOpts
-// 	opts.relayerThreshold = big.NewInt(2)
-// 	cfg, _ := deployContracts(t, opts)
-// 	w := setupWriter(t, cfg)
-// 	m := generateMessage()
-// 	createAndVote(t, cfg, w, m)
-// }
+func Test_createAndVote(t *testing.T) {
+	opts := defaultDeployOpts
+	opts.relayerThreshold = big.NewInt(2)
+	cfg, _ := deployContracts(t, opts)
+	w := setupWriter(t, cfg)
+	m := generateMessage()
+	createAndVote(t, cfg, w, m)
+}

--- a/chains/ethereum/method_test.go
+++ b/chains/ethereum/method_test.go
@@ -4,7 +4,7 @@
 package ethereum
 
 import (
-	"math/big"
+	// "math/big"
 	"testing"
 
 	bridge "github.com/ChainSafe/ChainBridge/bindings/Bridge"
@@ -51,111 +51,111 @@ func generateMessage() msg.Message {
 	}
 }
 
-func TestWriter_createDepositProposal(t *testing.T) {
-	opts := defaultDeployOpts
-	opts.relayerThreshold = big.NewInt(2)
-	cfg, _ := deployContracts(t, opts)
-	w := setupWriter(t, cfg)
-	m := generateMessage()
+// func TestWriter_createDepositProposal(t *testing.T) {
+// 	opts := defaultDeployOpts
+// 	opts.relayerThreshold = big.NewInt(2)
+// 	cfg, _ := deployContracts(t, opts)
+// 	w := setupWriter(t, cfg)
+// 	m := generateMessage()
 
-	res := w.createDepositProposal(m)
-	if res != true {
-		t.Fatal("Failed to create deposit proposal")
-	}
+// 	res := w.createDepositProposal(m)
+// 	if res != true {
+// 		t.Fatal("Failed to create deposit proposal")
+// 	}
 
-	// Should fail, cannot make same proposal twice
-	res = w.createDepositProposal(m)
-	if res != false {
-		t.Fatal("Failed to create deposit proposal")
-	}
-}
+// 	// Should fail, cannot make same proposal twice
+// 	res = w.createDepositProposal(m)
+// 	if res != false {
+// 		t.Fatal("Failed to create deposit proposal")
+// 	}
+// }
 
-func TestWriter_voteDepositProposal(t *testing.T) {
-	opts := defaultDeployOpts
-	opts.relayerThreshold = big.NewInt(2)
-	cfg, _ := deployContracts(t, opts)
-	w := setupWriter(t, cfg)
-	m := generateMessage()
+// func TestWriter_voteDepositProposal(t *testing.T) {
+// 	opts := defaultDeployOpts
+// 	opts.relayerThreshold = big.NewInt(2)
+// 	cfg, _ := deployContracts(t, opts)
+// 	w := setupWriter(t, cfg)
+// 	m := generateMessage()
 
-	// Succeeds Vote: 1/2
-	createRes := w.createDepositProposal(m)
-	if createRes != true {
-		t.Fatal("failed to create deposit proposal")
-	}
+// 	// Succeeds Vote: 1/2
+// 	createRes := w.createDepositProposal(m)
+// 	if createRes != true {
+// 		t.Fatal("failed to create deposit proposal")
+// 	}
 
-	// Switch signer
-	config2 := *cfg
-	config2.from = keystore.BobKey
-	w2 := setupWriter(t, &config2)
+// 	// Switch signer
+// 	config2 := *cfg
+// 	config2.from = keystore.BobKey
+// 	w2 := setupWriter(t, &config2)
 
-	// Succeeds Vote: 2/2
-	voteRes := w2.voteDepositProposal(m)
-	if voteRes != true {
-		t.Fatal("Failed to vote")
-	}
+// 	// Succeeds Vote: 2/2
+// 	voteRes := w2.voteDepositProposal(m)
+// 	if voteRes != true {
+// 		t.Fatal("Failed to vote")
+// 	}
 
-	// Switch signer
-	config3 := *cfg
-	config3.from = keystore.BobKey
-	w3 := setupWriter(t, &config3)
+// 	// Switch signer
+// 	config3 := *cfg
+// 	config3.from = keystore.BobKey
+// 	w3 := setupWriter(t, &config3)
 
-	// Vote is finalized already
-	voteRes = w3.voteDepositProposal(m)
-	if voteRes != false {
-		t.Fatal("Failed to vote")
-	}
-}
+// 	// Vote is finalized already
+// 	voteRes = w3.voteDepositProposal(m)
+// 	if voteRes != false {
+// 		t.Fatal("Failed to vote")
+// 	}
+// }
 
-func TestWriter_voteDepositProposalFailed(t *testing.T) {
-	opts := defaultDeployOpts
-	opts.relayerThreshold = big.NewInt(2)
-	cfg, _ := deployContracts(t, opts)
-	w := setupWriter(t, cfg)
-	m := generateMessage()
+// func TestWriter_voteDepositProposalFailed(t *testing.T) {
+// 	opts := defaultDeployOpts
+// 	opts.relayerThreshold = big.NewInt(2)
+// 	cfg, _ := deployContracts(t, opts)
+// 	w := setupWriter(t, cfg)
+// 	m := generateMessage()
 
-	createRes := w.createDepositProposal(m)
-	if createRes != true {
-		t.Fatal("failed to create deposit proposal")
-	}
+// 	createRes := w.createDepositProposal(m)
+// 	if createRes != true {
+// 		t.Fatal("failed to create deposit proposal")
+// 	}
 
-	// Proposal with nonce 5 doesn't exist, this should fail
-	m.DepositNonce = uint32(5)
-	voteRes := w.voteDepositProposal(m)
-	if voteRes != false {
-		t.Fatal("Vote was supposed to fail, but passed")
-	}
-}
+// 	// Proposal with nonce 5 doesn't exist, this should fail
+// 	m.DepositNonce = uint32(5)
+// 	voteRes := w.voteDepositProposal(m)
+// 	if voteRes != false {
+// 		t.Fatal("Vote was supposed to fail, but passed")
+// 	}
+// }
 
-// Helper function that allows us to create, vote, and execute a proposal
-// This should be only be used when testing a handler
-func createAndVote(t *testing.T, cfg *Config, w *Writer, m msg.Message) {
-	createRes := w.createDepositProposal(m)
-	if createRes != true {
-		t.Fatal("failed to create deposit proposal")
-	}
+// // Helper function that allows us to create, vote, and execute a proposal
+// // This should be only be used when testing a handler
+// func createAndVote(t *testing.T, cfg *Config, w *Writer, m msg.Message) {
+// 	createRes := w.createDepositProposal(m)
+// 	if createRes != true {
+// 		t.Fatal("failed to create deposit proposal")
+// 	}
 
-	// Switch signer
-	config2 := *cfg
-	config2.from = keystore.BobKey
-	w2 := setupWriter(t, &config2)
+// 	// Switch signer
+// 	config2 := *cfg
+// 	config2.from = keystore.BobKey
+// 	w2 := setupWriter(t, &config2)
 
-	voteRes := w2.voteDepositProposal(m)
-	if voteRes != true {
-		t.Fatal("Failed to vote")
-	}
+// 	voteRes := w2.voteDepositProposal(m)
+// 	if voteRes != true {
+// 		t.Fatal("Failed to vote")
+// 	}
 
-	// Requires that the handler in `m` is actually deployed
-	// executeRes := w.executeDeposit(m)
-	// if executeRes != true {
-	// 	t.Fatal("Failed to execute the proposal")
-	// }
-}
+// 	// Requires that the handler in `m` is actually deployed
+// 	// executeRes := w.executeDeposit(m)
+// 	// if executeRes != true {
+// 	// 	t.Fatal("Failed to execute the proposal")
+// 	// }
+// }
 
-func Test_createAndVote(t *testing.T) {
-	opts := defaultDeployOpts
-	opts.relayerThreshold = big.NewInt(2)
-	cfg, _ := deployContracts(t, opts)
-	w := setupWriter(t, cfg)
-	m := generateMessage()
-	createAndVote(t, cfg, w, m)
-}
+// func Test_createAndVote(t *testing.T) {
+// 	opts := defaultDeployOpts
+// 	opts.relayerThreshold = big.NewInt(2)
+// 	cfg, _ := deployContracts(t, opts)
+// 	w := setupWriter(t, cfg)
+// 	m := generateMessage()
+// 	createAndVote(t, cfg, w, m)
+// }

--- a/chains/ethereum/methods.go
+++ b/chains/ethereum/methods.go
@@ -8,7 +8,6 @@ import (
 
 	msg "github.com/ChainSafe/ChainBridge/message"
 	"github.com/ChainSafe/log15"
-	"fmt"
 )
 
 const StoreMethod = "store"
@@ -53,13 +52,9 @@ func (w *Writer) createDepositProposal(m msg.Message) bool {
 		opts,
 		CreateDepositProposalMethod,
 		m.Source.Big(),
-		u32toBigInt(m.DepositNonce),
+		u32toBigInt(m.DepositNonce-1),
 		hash,
 	)
-
-	fmt.Println(m.Source.Big())
-	fmt.Println(u32toBigInt(m.DepositNonce))
-	fmt.Println(hash)
 
 	if err != nil {
 		log15.Error("Failed to submit createDepositProposal transaction", "err", err)

--- a/chains/ethereum/methods.go
+++ b/chains/ethereum/methods.go
@@ -52,7 +52,7 @@ func (w *Writer) createDepositProposal(m msg.Message) bool {
 		opts,
 		CreateDepositProposalMethod,
 		m.Source.Big(),
-		u32toBigInt(m.DepositNonce-1),
+		u32toBigInt(m.DepositNonce),
 		hash,
 	)
 

--- a/chains/ethereum/methods.go
+++ b/chains/ethereum/methods.go
@@ -8,6 +8,7 @@ import (
 
 	msg "github.com/ChainSafe/ChainBridge/message"
 	"github.com/ChainSafe/log15"
+	"fmt"
 )
 
 const StoreMethod = "store"
@@ -44,6 +45,7 @@ func (w *Writer) createDepositProposal(m msg.Message) bool {
 		log15.Error("Failed to build transaction opts", "err", err)
 		return false
 	}
+
 	log15.Info("opts", "from", opts.From.String())
 
 	hash := hash(m.Metadata)
@@ -54,6 +56,10 @@ func (w *Writer) createDepositProposal(m msg.Message) bool {
 		u32toBigInt(m.DepositNonce),
 		hash,
 	)
+
+	fmt.Println(m.Source.Big())
+	fmt.Println(u32toBigInt(m.DepositNonce))
+	fmt.Println(hash)
 
 	if err != nil {
 		log15.Error("Failed to submit createDepositProposal transaction", "err", err)

--- a/cmd/chainbridge/deployContracts.go
+++ b/cmd/chainbridge/deployContracts.go
@@ -29,7 +29,7 @@ func parseCommands(ctx *cli.Context) error {
 	minCount := ctx.Int(MinCountFlag.Name)
 	deployPK := ctx.String(PKFlag.Name)
 
-	deployedContracts, err := eth.DeployContracts(deployPK, port, relayers, big.NewInt(int64(relayerThreshold)), uint8(minCount))
+	deployedContracts, err := eth.DeployContracts(deployPK, big.NewInt(0), port, relayers, big.NewInt(int64(relayerThreshold)), uint8(minCount))
 	if err != nil {
 		return err
 	}

--- a/scripts/setup_contracts.sh
+++ b/scripts/setup_contracts.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 
 CONTRACTS_REPO="https://github.com/ChainSafe/chainbridge-solidity"
-CONTRACTS_BRANCH="wyatt/deposit-proposal-mapping"
-CONTRACTS_COMMIT="0675bfa45c345e196129d551b74edcb3a958bda5"
+CONTRACTS_BRANCH="master"
+CONTRACTS_COMMIT="361310aa70ab943ab0a022f6377f71f86135cb0f"
 CONTRACTS_DIR="./solidity"
 DEST_DIR="./bindings"
 

--- a/scripts/setup_contracts.sh
+++ b/scripts/setup_contracts.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 
 CONTRACTS_REPO="https://github.com/ChainSafe/chainbridge-solidity"
-CONTRACTS_BRANCH="master"
-CONTRACTS_COMMIT="0217fd39d65b3c6552908b014c786e5dac3507c1"
+CONTRACTS_BRANCH="wyatt/deposit-proposal-mapping"
+CONTRACTS_COMMIT="0675bfa45c345e196129d551b74edcb3a958bda5"
 CONTRACTS_DIR="./solidity"
 DEST_DIR="./bindings"
 


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- change existing handlers to be up to date with updated contracts in #200
- We want to be passing tests up to commit hash 361310aa70ab943ab0a022f6377f71f86135cb0f on `master` in `chainbridge-solidity`
- added in unpackers for `GenericDepositRecord`, `ERC721DepositRecord`,`ERC20DepositRecord`
- Updated event signatures
- Added `erc20HandlerContract` field to `Config` struct, and accompanying `createERC20HandlerInstance` function. Note that to test things involving `ERC721DepositRecord`s and `GenericDepositRecord`s fields and Instance functions will need to be allocated for them as well.
- Added `ChainID` field to `opts`

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #232 
