### PR TITLE
Changing Generating Private Key to Importing Private Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ To use secure keys, see `chainbridge accounts --help`. The keystore password can
 
 To import external ethereum keys, such as those generated with geth, use `chainbridge accounts import --ethereum /path/to/key`.
 
+To import private keys as keystores, use `chainbridge account import --privateKey key`.
+
 For testing purposes, chainbridge provides 5 test keys. The can be used with `--testkey <name>`, where `name` is one of `Alice`, `Bob`, `Charlie`, `Dave`, or `Eve`. 
 
 # Chain Implementations

--- a/cmd/chainbridge/account.go
+++ b/cmd/chainbridge/account.go
@@ -62,17 +62,7 @@ func handleGenerateCmd(ctx *cli.Context, dHandler *dataHandler) error {
 		password = []byte(pwdflag)
 	}
 
-	var privKey string = ""
-	if privkeyflag := ctx.String(PrivateKeyFlag.Name); privkeyflag != "" {
-		// Hex must not have leading 0x
-		if privkeyflag[0:2] == "0x" {
-			privKey = privkeyflag[2:]
-		} else {
-			privKey = privkeyflag
-		}
-	}
-
-	_, err := generateKeypair(keytype, dHandler.datadir, password, privKey)
+	_, err := generateKeypair(keytype, dHandler.datadir, password)
 	if err != nil {
 		return fmt.Errorf("failed to generate key: %s", err)
 	}
@@ -85,12 +75,36 @@ func handleImportCmd(ctx *cli.Context, dHandler *dataHandler) error {
 	// import key
 	if keyimport := ctx.Args().First(); keyimport != "" {
 		var err error
+
 		log.Info("Importing key...")
+
+		// check if --ed25519 or --sr25519 is set
+		keytype := crypto.Secp256k1Type
+		if flagtype := ctx.Bool(Sr25519Flag.Name); flagtype {
+			keytype = crypto.Sr25519Type
+		} else if flagtype := ctx.Bool(Secp256k1Flag.Name); flagtype {
+			keytype = crypto.Secp256k1Type
+		}
+
 		if ctx.Bool(EthereumImportFlag.Name) {
 			_, err = importEthKey(keyimport, dHandler.datadir)
+		} else if privkeyflag := ctx.String(PrivateKeyFlag.Name); privkeyflag != "" {
+			// check if --password is set
+			var password []byte = nil
+			if pwdflag := ctx.String(PasswordFlag.Name); pwdflag != "" {
+				password = []byte(pwdflag)
+			}
+
+			// Hex must not have leading 0x
+			if privkeyflag[0:2] == "0x" {
+				_, err = importPrivKey(keytype, privkeyflag[0:2], dHandler.datadir, password)
+			} else {
+				_, err = importPrivKey(keytype, privkeyflag, dHandler.datadir, password)
+			}
 		} else {
 			_, err = importKey(keyimport, dHandler.datadir)
 		}
+
 		if err != nil {
 			return fmt.Errorf("failed to import key: %s", err)
 		}
@@ -126,7 +140,63 @@ func getDataDir(ctx *cli.Context) (string, error) {
 	return "", fmt.Errorf("datadir flag not supplied")
 }
 
-//Imports ether keys
+func importPrivKey(keytype, datadir, key string, password []byte) (string, error) {
+	if password == nil {
+		password = keystore.GetPassword("Enter password to encrypt keystore file:")
+	}
+	keystorepath, err := keystoreDir(datadir)
+
+	if keytype == "" {
+		log.Info("Using default key type", "type", keytype)
+		keytype = crypto.Secp256k1Type
+	}
+
+	var kp crypto.Keypair
+
+	if keytype == crypto.Sr25519Type {
+		// generate sr25519 keys
+		kp, err = sr25519.NewKeypairFromSeed(key)
+		if err != nil {
+			return "", fmt.Errorf("could not generate sr25519 keypair from given string: %s", err)
+		}
+	} else if keytype == crypto.Secp256k1Type {
+		// generate secp256k1 keys
+		kp, err = secp256k1.NewKeypairFromString(key)
+		if err != nil {
+			return "", fmt.Errorf("could not generate secp256k1 keypair from given string: %s", err)
+		}
+	} else {
+		return "", fmt.Errorf("invalid key type: %s", keytype)
+	}
+
+	fp, err := filepath.Abs(keystorepath + "/" + kp.PublicKey() + ".key")
+	if err != nil {
+		return "", fmt.Errorf("invalid filepath: %s", err)
+	}
+
+	file, err := os.OpenFile(fp, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return "", fmt.Errorf("Unable to Open File: %s", err)
+	}
+
+	defer func() {
+		err = file.Close()
+		if err != nil {
+			log.Error("import private key: could not close keystore file")
+		}
+	}()
+
+	err = keystore.EncryptAndWriteToFile(file, kp, password)
+	if err != nil {
+		return "", fmt.Errorf("could not write key to file: %s", err)
+	}
+
+	log.Info("private key imported", "public key", kp.PublicKey(), "file", fp)
+	return fp, nil
+
+}
+
+//importEthKey takes an ethereum keystore and converts it to our keystore format
 func importEthKey(filename, datadir string) (string, error) {
 	keystorepath, err := keystoreDir(datadir)
 	if err != nil {
@@ -252,7 +322,7 @@ func getKeyFiles(datadir string) ([]string, error) {
 // generateKeypair create a new keypair with the corresponding type and saves it to datadir/keystore/[public key].key
 // in json format encrypted using the specified password
 // it returns the resulting filepath of the new key
-func generateKeypair(keytype, datadir string, password []byte, privateKey string) (string, error) {
+func generateKeypair(keytype, datadir string, password []byte) (string, error) {
 	if password == nil {
 		password = keystore.GetPassword("Enter password to encrypt keystore file:")
 	}
@@ -267,29 +337,15 @@ func generateKeypair(keytype, datadir string, password []byte, privateKey string
 
 	if keytype == crypto.Sr25519Type {
 		// generate sr25519 keys
-		if privateKey != "" {
-			kp, err = sr25519.NewKeypairFromSeed(privateKey)
-			if err != nil {
-				return "", fmt.Errorf("could not generate secp256k1 keypair from given string: %s", err)
-			}
-		} else {
-			kp, err = sr25519.GenerateKeypair()
-			if err != nil {
-				return "", fmt.Errorf("could not generate sr25519 keypair: %s", err)
-			}
+		kp, err = sr25519.GenerateKeypair()
+		if err != nil {
+			return "", fmt.Errorf("could not generate sr25519 keypair: %s", err)
 		}
 	} else if keytype == crypto.Secp256k1Type {
 		// generate secp256k1 keys
-		if privateKey != "" {
-			kp, err = secp256k1.NewKeypairFromString(privateKey)
-			if err != nil {
-				return "", fmt.Errorf("could not generate secp256k1 keypair from given string: %s", err)
-			}
-		} else {
-			kp, err = secp256k1.GenerateKeypair()
-			if err != nil {
-				return "", fmt.Errorf("could not generate secp256k1 keypair: %s", err)
-			}
+		kp, err = secp256k1.GenerateKeypair()
+		if err != nil {
+			return "", fmt.Errorf("could not generate secp256k1 keypair: %s", err)
 		}
 	} else {
 		return "", fmt.Errorf("invalid key type: %s", keytype)

--- a/cmd/chainbridge/account.go
+++ b/cmd/chainbridge/account.go
@@ -140,6 +140,7 @@ func getDataDir(ctx *cli.Context) (string, error) {
 	return "", fmt.Errorf("datadir flag not supplied")
 }
 
+//importPrivKey imports a private key into a keypair
 func importPrivKey(keytype, datadir, key string, password []byte) (string, error) {
 	if password == nil {
 		password = keystore.GetPassword("Enter password to encrypt keystore file:")

--- a/cmd/chainbridge/account.go
+++ b/cmd/chainbridge/account.go
@@ -97,9 +97,9 @@ func handleImportCmd(ctx *cli.Context, dHandler *dataHandler) error {
 
 			// Hex must not have leading 0x
 			if privkeyflag[0:2] == "0x" {
-				_, err = importPrivKey(keytype, privkeyflag[0:2], dHandler.datadir, password)
+				_, err = importPrivKey(keytype, dHandler.datadir, privkeyflag[0:2], password)
 			} else {
-				_, err = importPrivKey(keytype, privkeyflag, dHandler.datadir, password)
+				_, err = importPrivKey(keytype, dHandler.datadir, privkeyflag, password)
 			}
 		} else {
 			_, err = importKey(keyimport, dHandler.datadir)

--- a/cmd/chainbridge/account_test.go
+++ b/cmd/chainbridge/account_test.go
@@ -20,7 +20,7 @@ var testKeystoreDir = "./test_datadir/"
 var testPassword = []byte("1234")
 
 func TestGenerateKey_NoType(t *testing.T) {
-	keyfile, err := generateKeypair("", testKeystoreDir, testPassword, "")
+	keyfile, err := generateKeypair("", testKeystoreDir, testPassword)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,27 +43,25 @@ func TestGenerateKey_NoType(t *testing.T) {
 	}
 }
 
-func TestGenerateKey_withPk(t *testing.T) {
-	keyfile, err := generateKeypair("", testKeystoreDir, testPassword, "000000000000000000000000000000000000000000000000000000416c696365")
+func TestImportKey_withPk(t *testing.T) {
+	keyfile, err := importPrivKey("", testKeystoreDir, "000000000000000000000000000000000000000000000000000000416c696365", testPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err := listKeys(testKeystoreDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer os.RemoveAll(testKeystoreDir)
 
-	contents, err := ioutil.ReadFile(keyfile)
-	if err != nil {
-		t.Fatal(err)
+	if len(keys) != 1 {
+		t.Fatal("fail")
 	}
 
-	kscontents := new(keystore.EncryptedKeystore)
-	err = json.Unmarshal(contents, kscontents)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if kscontents.Type != "secp256k1" {
-		t.Fatalf("Fail: got %s expected %s", kscontents.Type, "secp256k1")
+	if strings.Compare(keys[0], filepath.Base(keyfile)) != 0 {
+		t.Fatalf("Fail: got %s expected %s", keys[0], keyfile)
 	}
 }
 
@@ -77,7 +75,7 @@ func TestImportKey_ShouldFail(t *testing.T) {
 func TestImportKey(t *testing.T) {
 	keypath := "../../"
 
-	importkeyfile, err := generateKeypair("sr25519", keypath, testPassword, "")
+	importkeyfile, err := generateKeypair("sr25519", keypath, testPassword)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,12 +111,12 @@ func TestListKeys(t *testing.T) {
 		var err error
 		var keyfile string
 		if i%2 == 0 {
-			keyfile, err = generateKeypair(crypto.Sr25519Type, testKeystoreDir, testPassword, "")
+			keyfile, err = generateKeypair(crypto.Sr25519Type, testKeystoreDir, testPassword)
 			if err != nil {
 				t.Fatal(err)
 			}
 		} else {
-			keyfile, err = generateKeypair(crypto.Secp256k1Type, testKeystoreDir, testPassword, "")
+			keyfile, err = generateKeypair(crypto.Secp256k1Type, testKeystoreDir, testPassword)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/chainbridge/account_test.go
+++ b/cmd/chainbridge/account_test.go
@@ -43,8 +43,24 @@ func TestGenerateKey_NoType(t *testing.T) {
 	}
 }
 
-func TestImportKey_withPk(t *testing.T) {
-	keyfile, err := importPrivKey("", testKeystoreDir, "000000000000000000000000000000000000000000000000000000416c696365", testPassword)
+func TestImportKey_ShouldFail(t *testing.T) {
+	_, err := importKey("./notakey.key", testKeystoreDir)
+	if err == nil {
+		t.Fatal("did not err")
+	}
+}
+
+func TestImportKey(t *testing.T) {
+	keypath := "../../"
+
+	importkeyfile, err := generateKeypair("sr25519", keypath, testPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(importkeyfile)
+
+	keyfile, err := importKey(importkeyfile, testKeystoreDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,24 +81,8 @@ func TestImportKey_withPk(t *testing.T) {
 	}
 }
 
-func TestImportKey_ShouldFail(t *testing.T) {
-	_, err := importKey("./notakey.key", testKeystoreDir)
-	if err == nil {
-		t.Fatal("did not err")
-	}
-}
-
-func TestImportKey(t *testing.T) {
-	keypath := "../../"
-
-	importkeyfile, err := generateKeypair("sr25519", keypath, testPassword)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(importkeyfile)
-
-	keyfile, err := importKey(importkeyfile, testKeystoreDir)
+func TestImportKey_withPk(t *testing.T) {
+	keyfile, err := importPrivKey("", testKeystoreDir, "000000000000000000000000000000000000000000000000000000416c696365", testPassword)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/chainbridge/flags.go
+++ b/cmd/chainbridge/flags.go
@@ -29,10 +29,6 @@ var (
 
 // Generate subcommand flags
 var (
-	PrivateKeyFlag = cli.StringFlag{
-		Name:  "privateKey",
-		Usage: "Hex string private key used to generate a keypair.",
-	}
 	PasswordFlag = cli.StringFlag{
 		Name:  "password",
 		Usage: "Password used to encrypt the keystore. Used with --generate or --unlock",
@@ -51,6 +47,10 @@ var (
 	EthereumImportFlag = cli.BoolFlag{
 		Name:  "ethereum",
 		Usage: "Import an existing ethereum keystore",
+	}
+	PrivateKeyFlag = cli.StringFlag{
+		Name:  "privateKey",
+		Usage: "Hex string private key used to generate a keypair.",
 	}
 )
 

--- a/cmd/chainbridge/main.go
+++ b/cmd/chainbridge/main.go
@@ -24,7 +24,6 @@ var cliFlags = []cli.Flag{
 }
 
 var generateFlags = []cli.Flag{
-	PrivateKeyFlag,
 	PasswordFlag,
 	Sr25519Flag,
 	Secp256k1Flag,
@@ -36,6 +35,10 @@ var devFlags = []cli.Flag{
 
 var importFlags = []cli.Flag{
 	EthereumImportFlag,
+	PrivateKeyFlag,
+	Sr25519Flag,
+	Secp256k1Flag,
+	PasswordFlag,
 }
 
 var accountCommand = cli.Command{


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Adds Private Key imports to the import command
- Removes the functionality from the Generate Command
- Added `Secp256k1`, `sr25519`, `password` and `privateKey` flags to import to maintain functionality.

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #317 
