### PR TITLE
Process Event Blocks in Ethereum Block by Block

### DIFF
--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -121,7 +121,7 @@ func (l *Listener) pollBlocks() error {
 func (l *Listener) getEventsForBlock(latestBlock *big.Int) error {
 
 	for evt, sub := range l.subscriptions {
-		query := buildSingleBlockQuery(l.cfg.bridgeContract, evt, latestBlock)
+		query := buildQuery(l.cfg.bridgeContract, evt, latestBlock, latestBlock)
 
 		logs, err := l.conn.conn.FilterLogs(l.conn.ctx, query)
 		if err != nil {
@@ -141,21 +141,10 @@ func (l *Listener) getEventsForBlock(latestBlock *big.Int) error {
 }
 
 // buildQuery constructs a query for the bridgeContract by hashing sig to get the event topic
-func buildQuery(contract ethcommon.Address, sig EventSig, startBlock *big.Int) eth.FilterQuery {
+func buildQuery(contract ethcommon.Address, sig EventSig, startBlock *big.Int, endBlock *big.Int) eth.FilterQuery {
 	query := eth.FilterQuery{
 		FromBlock: startBlock,
-		Addresses: []ethcommon.Address{contract},
-		Topics: [][]ethcommon.Hash{
-			{sig.GetTopic()},
-		},
-	}
-	return query
-}
-
-func buildSingleBlockQuery(contract ethcommon.Address, sig EventSig, startBlock *big.Int) eth.FilterQuery {
-	query := eth.FilterQuery{
-		FromBlock: startBlock,
-		ToBlock:   startBlock,
+		ToBlock:   endBlock,
 		Addresses: []ethcommon.Address{contract},
 		Topics: [][]ethcommon.Hash{
 			{sig.GetTopic()},
@@ -178,11 +167,6 @@ func (l *Listener) RegisterEventHandler(subscription EventSig, handler evtHandle
 
 	return nil
 
-}
-
-// Unsubscribe cancels a subscription for the given event
-func (l *Listener) Unsubscribe(sig EventSig) {
-	delete(l.subscriptions, sig)
 }
 
 // Stop cancels all subscriptions. Must be called before Connection.Stop().

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -4,7 +4,9 @@
 package ethereum
 
 import (
+	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ChainSafe/ChainBridge/chains"
 	"github.com/ChainSafe/log15"
@@ -12,6 +14,8 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 )
+
+var BlockRetryInterval = time.Second * 2
 
 type Subscription struct {
 	signature EventSig
@@ -26,7 +30,7 @@ type ActiveSubscription struct {
 type Listener struct {
 	cfg                  Config
 	conn                 *Connection
-	subscriptions        map[EventSig]*ActiveSubscription
+	subscriptions        map[EventSig]*Subscription
 	router               chains.Router
 	bridgeContract       *BridgeContract       // instance of bound bridge contract
 	erc20HandlerContract *ERC20HandlerContract // instance of bound erc20 handler
@@ -37,7 +41,7 @@ func NewListener(conn *Connection, cfg *Config, log log15.Logger) *Listener {
 	return &Listener{
 		cfg:           *cfg,
 		conn:          conn,
-		subscriptions: make(map[EventSig]*ActiveSubscription),
+		subscriptions: make(map[EventSig]*Subscription),
 		log:           log,
 	}
 }
@@ -65,6 +69,14 @@ func (l *Listener) GetSubscriptions() []*Subscription {
 // Start registers all subscriptions provided by the config
 func (l *Listener) Start() error {
 	l.log.Debug("Starting listener...")
+	currBlock, err := l.conn.conn.BlockByNumber(l.conn.ctx, nil)
+	if err != nil {
+		return fmt.Errorf("Unable to get starting Block: %s", err)
+	}
+	if currBlock.Number().Cmp(l.cfg.startBlock) < 0 {
+		return fmt.Errorf("starting block (%d) is greater than latest known block (%d)", l.cfg.startBlock, currBlock.Number())
+	}
+
 	subscriptions := l.GetSubscriptions()
 	for _, sub := range subscriptions {
 		err := l.RegisterEventHandler(sub.signature, sub.handler)
@@ -72,11 +84,60 @@ func (l *Listener) Start() error {
 			l.log.Error("failed to register event handler", "err", err)
 		}
 	}
+
+	go func() {
+		err := l.pollBlocks()
+		if err != nil {
+			l.log.Error("Polling blocks failed", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+//pollBlocks continously check the blocks for subscription logs, and sends messages to the router if logs are encountered
+// stops where there are no subscriptions, and sleeps if we are at the current block
+func (l *Listener) pollBlocks() error {
+	l.log.Debug("Polling Blocks...")
+	var latestBlock = l.cfg.startBlock
+	for {
+		if len(l.subscriptions) == 0 {
+			l.log.Debug("No subscriptions, stopping Polling")
+			break
+		}
+		currBlock, err := l.conn.conn.BlockByNumber(l.conn.ctx, nil)
+		if err != nil {
+			return fmt.Errorf("Unable to get latest block: %s", err)
+		}
+		if currBlock.Number().Cmp(latestBlock) < 0 {
+			time.Sleep(BlockRetryInterval)
+			continue
+		}
+
+		for evt, sub := range l.subscriptions {
+			query := buildQuery(l.cfg.bridgeContract, evt, latestBlock)
+
+			logs, err := l.conn.conn.FilterLogs(l.conn.ctx, query)
+			if err != nil {
+				return fmt.Errorf("Unable to Filter Logs: %s", err)
+			}
+
+			for _, log := range logs {
+				m := sub.handler(log)
+				err = l.router.Send(m)
+				if err != nil {
+					l.log.Error("subscription error: cannot send message", "sub", sub, "err", err)
+				}
+			}
+		}
+
+		latestBlock.Add(latestBlock, big.NewInt(1))
+	}
+
 	return nil
 }
 
 // buildQuery constructs a query for the bridgeContract by hashing sig to get the event topic
-// TODO: Start from current block
 func buildQuery(contract ethcommon.Address, sig EventSig, startBlock *big.Int) eth.FilterQuery {
 	query := eth.FilterQuery{
 		FromBlock: startBlock,
@@ -91,48 +152,30 @@ func buildQuery(contract ethcommon.Address, sig EventSig, startBlock *big.Int) e
 // RegisterEventHandler creates a subscription for the provided event on the bridge bridgeContract.
 // Handler will be called for every instance of event.
 func (l *Listener) RegisterEventHandler(subscription EventSig, handler evtHandlerFn) error {
-	evt := subscription
-	query := buildQuery(l.cfg.bridgeContract, evt, l.cfg.startBlock)
-	eventSubscription, err := l.conn.subscribeToEvent(query)
-	if err != nil {
-		return err
-	}
-	l.subscriptions[subscription] = eventSubscription
-	go l.watchEvent(eventSubscription, handler)
-	l.log.Debug("Registered event handler", "bridgeContract", l.cfg.bridgeContract, "sig", subscription)
-	return nil
-}
 
-// watchEvent will call the handler for every occurrence of the corresponding event. It should be run in a separate
-// goroutine to monitor the subscription channel.
-func (l *Listener) watchEvent(eventSubscription *ActiveSubscription, handler evtHandlerFn) {
-	for {
-		select {
-		case evt := <-eventSubscription.ch:
-			m := handler(evt)
-			err := l.router.Send(m)
-			if err != nil {
-				l.log.Error("subscription error: cannot send message", "sub", eventSubscription, "err", err)
-			}
-		case err := <-eventSubscription.sub.Err():
-			if err != nil {
-				l.log.Error("subscription error", "err", err)
-			}
-		}
+	if l.subscriptions[subscription] != nil {
+		return fmt.Errorf("event %s already registered", subscription)
 	}
+	sub := new(Subscription)
+	sub.handler = handler
+	sub.signature = subscription
+	l.subscriptions[subscription] = sub
+
+	return nil
+
 }
 
 // Unsubscribe cancels a subscription for the given event
 func (l *Listener) Unsubscribe(sig EventSig) {
 	if _, ok := l.subscriptions[sig]; ok {
-		l.subscriptions[sig].sub.Unsubscribe()
+		delete(l.subscriptions, sig)
 	}
 }
 
 // Stop cancels all subscriptions. Must be called before Connection.Stop().
 func (l *Listener) Stop() error {
-	for _, sub := range l.subscriptions {
-		sub.sub.Unsubscribe()
+	for sig, _ := range l.subscriptions {
+		delete(l.subscriptions, sig)
 	}
 	return nil
 }

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -182,9 +182,7 @@ func (l *Listener) RegisterEventHandler(subscription EventSig, handler evtHandle
 
 // Unsubscribe cancels a subscription for the given event
 func (l *Listener) Unsubscribe(sig EventSig) {
-	if _, ok := l.subscriptions[sig]; ok {
-		delete(l.subscriptions, sig)
-	}
+	delete(l.subscriptions, sig)
 }
 
 // Stop cancels all subscriptions. Must be called before Connection.Stop().

--- a/chains/ethereum/listener.go
+++ b/chains/ethereum/listener.go
@@ -189,7 +189,7 @@ func (l *Listener) Unsubscribe(sig EventSig) {
 
 // Stop cancels all subscriptions. Must be called before Connection.Stop().
 func (l *Listener) Stop() error {
-	for sig, _ := range l.subscriptions {
+	for sig := range l.subscriptions {
 		delete(l.subscriptions, sig)
 	}
 	return nil

--- a/chains/ethereum/listener_test.go
+++ b/chains/ethereum/listener_test.go
@@ -29,6 +29,7 @@ func createTestListener(t *testing.T, config *Config, contracts *DeployedContrac
 	newConfig := *config
 	newConfig.bridgeContract = contracts.BridgeAddress
 	newConfig.erc20HandlerContract = contracts.ERC20HandlerAddress
+	newConfig.startBlock = big.NewInt(0)
 
 	conn := newLocalConnection(t, &newConfig)
 	bridgeContract, err := createBridgeContract(newConfig.bridgeContract, conn)

--- a/chains/ethereum/writer_methods.go
+++ b/chains/ethereum/writer_methods.go
@@ -96,7 +96,7 @@ func (w *Writer) createGenericDepositProposal(m msg.Message) bool {
 func (w *Writer) watchAndExecute(m msg.Message, handler common.Address, data []byte) {
 	w.log.Trace("Watching for finalization event", "depositNonce", m.DepositNonce)
 	// TODO: Skip existing blocks
-	query := buildQuery(w.cfg.bridgeContract, DepositProposalFinalized, w.cfg.startBlock)
+	query := buildQuery(w.cfg.bridgeContract, DepositProposalFinalized, w.cfg.startBlock, nil)
 	eventSubscription, err := w.conn.subscribeToEvent(query)
 	if err != nil {
 		w.log.Error("Failed to subscribe to finalization event", "err", err)

--- a/chains/ethereum/writer_test.go
+++ b/chains/ethereum/writer_test.go
@@ -83,7 +83,7 @@ func TestHash(t *testing.T) {
 
 func watchEvent(conn *Connection, subStr EventSig) {
 	fmt.Printf("Watching for event: %s\n", subStr)
-	query := buildQuery(conn.cfg.bridgeContract, subStr, big.NewInt(0))
+	query := buildQuery(conn.cfg.bridgeContract, subStr, big.NewInt(0), nil)
 	eventSubscription, err := conn.subscribeToEvent(query)
 	if err != nil {
 		log15.Error("Failed to subscribe to finalization event", "err", err)
@@ -148,7 +148,7 @@ func TestCreateAndExecuteErc20DepositProposal(t *testing.T) {
 	go watchEvent(alice.conn, DepositProposalExecuted)
 
 	// Watch for executed event
-	query := buildQuery(alice.cfg.bridgeContract, DepositProposalExecuted, big.NewInt(0))
+	query := buildQuery(alice.cfg.bridgeContract, DepositProposalExecuted, big.NewInt(0), nil)
 	eventSubscription, err := alice.conn.subscribeToEvent(query)
 	if err != nil {
 		log15.Error("Failed to subscribe to finalization event", "err", err)
@@ -217,7 +217,7 @@ func TestCreateAndExecuteGenericProposal(t *testing.T) {
 	go watchEvent(alice.conn, DepositProposalExecuted)
 
 	// Watch for executed event
-	query := buildQuery(alice.cfg.bridgeContract, DepositProposalExecuted, big.NewInt(0))
+	query := buildQuery(alice.cfg.bridgeContract, DepositProposalExecuted, big.NewInt(0), nil)
 	eventSubscription, err := alice.conn.subscribeToEvent(query)
 	if err != nil {
 		log15.Error("Failed to subscribe to finalization event", "err", err)


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Changed the flow of `ethereum/listener.go` to poll blocks rather than wait for subscriptions.
- Updated Supporting functions
- removed the need for channels.

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #307
