### PR TITLE
Removing Check for Length in ERC721 Deposit

### DIFF
--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -36,15 +36,13 @@ func (l *listener) handleErc721DepositedEvent(destId msg.ChainId, nonce msg.Nonc
 		return msg.Message{}, err
 	}
 
-	recipient := record.DestinationRecipientAddress[:record.LenDestinationRecipientAddress.Int64()]
-
 	return msg.NewNonFungibleTransfer(
 		l.cfg.id,
 		destId,
 		nonce,
 		record.ResourceID,
 		record.TokenID,
-		recipient,
+		record.DestinationRecipientAddress,
 		record.MetaData,
 	), nil
 }


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Removes the length check for `ERC721` Deposits in `chains/ethereum/events.go`. 

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #397 
