### PR TITLE
Add flag to start from current block

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The blockstore is used to record the last block the relayer processed, so it can
 
 If a `startBlock` option is provided (see [Configuration](#configuration)), then the greater of `startBlock` and the latest block in the blockstore is used at startup.
 
-To disable loading from the blockstore specify the `--fresh` flag. A custom path for the blockstore can be provided with `--blockstore <path>`
+To disable loading from the blockstore specify the `--fresh` flag. A custom path for the blockstore can be provided with `--blockstore <path>`. For development, the `--latest` flag can be used to start from the current block and override any other configuration.
 
 ## Keystore
 

--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -145,6 +145,14 @@ func InitializeChain(chainCfg *core.ChainConfig, logger log15.Logger, sysErr cha
 		return nil, err
 	}
 
+	if chainCfg.LatestBlock {
+		curr, err := conn.LatestBlock()
+		if err != nil {
+			return nil, err
+		}
+		cfg.startBlock = curr
+	}
+
 	listener := NewListener(conn, cfg, logger, bs, stop, sysErr)
 	listener.setContracts(bridgeContract, erc20HandlerContract, erc721HandlerContract, genericHandlerContract)
 

--- a/chains/substrate/chain.go
+++ b/chains/substrate/chain.go
@@ -92,6 +92,14 @@ func InitializeChain(cfg *core.ChainConfig, logger log15.Logger, sysErr chan<- e
 		return nil, err
 	}
 
+	if cfg.LatestBlock {
+		curr, err := conn.api.RPC.Chain.GetHeaderLatest()
+		if err != nil {
+			return nil, err
+		}
+		startBlock = uint64(curr.Number)
+	}
+
 	// Setup listener & writer
 	l := NewListener(conn, cfg.Name, cfg.Id, startBlock, logger, bs, stop, sysErr)
 	w := NewWriter(conn, logger, sysErr)

--- a/cmd/chainbridge/main.go
+++ b/cmd/chainbridge/main.go
@@ -167,7 +167,7 @@ func run(ctx *cli.Context) error {
 			Insecure:       insecure,
 			BlockstorePath: ctx.GlobalString(config.BlockstorePathFlag.Name),
 			FreshStart:     ctx.GlobalBool(config.FreshStartFlag.Name),
-			LatestBlock: ctx.GlobalBool(config.LatestBlockFlag.Name),
+			LatestBlock:    ctx.GlobalBool(config.LatestBlockFlag.Name),
 			Opts:           chain.Opts,
 		}
 		var newChain core.Chain

--- a/cmd/chainbridge/main.go
+++ b/cmd/chainbridge/main.go
@@ -29,6 +29,7 @@ var cliFlags = []cli.Flag{
 	config.KeystorePathFlag,
 	config.BlockstorePathFlag,
 	config.FreshStartFlag,
+	config.LatestBlockFlag,
 }
 
 var generateFlags = []cli.Flag{
@@ -166,6 +167,7 @@ func run(ctx *cli.Context) error {
 			Insecure:       insecure,
 			BlockstorePath: ctx.GlobalString(config.BlockstorePathFlag.Name),
 			FreshStart:     ctx.GlobalBool(config.FreshStartFlag.Name),
+			LatestBlock: ctx.GlobalBool(config.LatestBlockFlag.Name),
 			Opts:           chain.Opts,
 		}
 		var newChain core.Chain

--- a/config/flags.go
+++ b/config/flags.go
@@ -38,8 +38,8 @@ var (
 	}
 
 	LatestBlockFlag = cli.BoolFlag{
-		Name:        "latest",
-		Usage:       "Overrides blockstore and start block, starts from latest block",
+		Name:  "latest",
+		Usage: "Overrides blockstore and start block, starts from latest block",
 	}
 )
 

--- a/config/flags.go
+++ b/config/flags.go
@@ -36,6 +36,11 @@ var (
 		Name:  "fresh",
 		Usage: "Disables loading from blockstore at start. Opts will still be used if specified.",
 	}
+
+	LatestBlockFlag = cli.BoolFlag{
+		Name:        "latest",
+		Usage:       "Overrides blockstore and start block, starts from latest block",
+	}
 )
 
 // Generate subcommand flags

--- a/core/chain.go
+++ b/core/chain.go
@@ -25,5 +25,6 @@ type ChainConfig struct {
 	Insecure       bool              // Indicated whether the test keyring should be used
 	BlockstorePath string            // Location of blockstore
 	FreshStart     bool              // If true, blockstore is ignored at start.
+	LatestBlock bool // If true, overrides blockstore or latest block in config and starts from current block
 	Opts           map[string]string // Per chain options
 }

--- a/core/chain.go
+++ b/core/chain.go
@@ -25,6 +25,6 @@ type ChainConfig struct {
 	Insecure       bool              // Indicated whether the test keyring should be used
 	BlockstorePath string            // Location of blockstore
 	FreshStart     bool              // If true, blockstore is ignored at start.
-	LatestBlock bool // If true, overrides blockstore or latest block in config and starts from current block
+	LatestBlock    bool              // If true, overrides blockstore or latest block in config and starts from current block
 	Opts           map[string]string // Per chain options
 }


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- add `--latest` flag, fetches current block for all chains and start from there if specified 

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #?
