### PR TITLE
GSRPC Update

### DIFF
--- a/chains/substrate/connection.go
+++ b/chains/substrate/connection.go
@@ -119,9 +119,9 @@ func (c *Connection) SubmitTx(method utils.Method, args ...interface{}) error {
 		BlockHash:   c.genesisHash,
 		Era:         types.ExtrinsicEra{IsMortalEra: false},
 		GenesisHash: c.genesisHash,
-		Nonce:       types.UCompact(c.nonce),
+		Nonce:       types.NewUCompactFromUInt(uint64(c.nonce)),
 		SpecVersion: rv.SpecVersion,
-		Tip:         0,
+		Tip:         types.NewUCompactFromUInt(0),
 	}
 
 	err = ext.Sign(*c.key, o)

--- a/chains/substrate/connection_test.go
+++ b/chains/substrate/connection_test.go
@@ -74,7 +74,7 @@ func TestConnect_SubmitTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = conn.SubmitTx("Balances.transfer", bob.AsAccountID, types.UCompact(10))
+	err = conn.SubmitTx("Balances.transfer", bob.AsAccountID, types.NewUCompactFromUInt(10))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200527185312-f0db52b1c793
 	github.com/ChainSafe/log15 v1.0.0
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
-	github.com/centrifuge/go-substrate-rpc-client v1.1.1-0.20200428140716-e238735648d6
+	github.com/centrifuge/go-substrate-rpc-client v2.0.0-alpha.3+incompatible
 	github.com/ethereum/go-ethereum v1.9.13
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli/v2 v2.2.0
 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
 )
+
+replace github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200527185312-f0db52b1c793 => github.com/mikiquantum/chainbridge-substrate-events v0.0.0-20200714203812-fb6d256611a4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ChainSafe/ChainBridge
 go 1.13
 
 require (
-	github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200527185312-f0db52b1c793
+	github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532025e
 	github.com/ChainSafe/log15 v1.0.0
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/centrifuge/go-substrate-rpc-client v2.0.0-alpha.3+incompatible
@@ -13,5 +13,3 @@ require (
 	github.com/urfave/cli/v2 v2.2.0
 	golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79
 )
-
-replace github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200527185312-f0db52b1c793 => github.com/mikiquantum/chainbridge-substrate-events v0.0.0-20200714203812-fb6d256611a4

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200527185312-f0db52b1c793 h1:sf/lEDGAjCqgC2BCGTUziaH4wltHh7rgcz/taIpk5Fc=
-github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200527185312-f0db52b1c793/go.mod h1:RSXnXog37jdV0A3j9uaZVjOxZ5Lrj5miNhjiMtQXZkM=
+github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532025e h1:c7NSjEfp13ua566bC2KSNmyx0Cvj1cciO2klsFIQv2I=
+github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532025e/go.mod h1:H5fNH57wn/j1oLifOnWEqYbfJZcOWzr7jZjKKrUckSQ=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -135,8 +135,6 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mikiquantum/chainbridge-substrate-events v0.0.0-20200714203812-fb6d256611a4 h1:lT6TEOf8Og8RitN/zaFgY0qT75wIHX+3K9JUXlheZfk=
-github.com/mikiquantum/chainbridge-substrate-events v0.0.0-20200714203812-fb6d256611a4/go.mod h1:H5fNH57wn/j1oLifOnWEqYbfJZcOWzr7jZjKKrUckSQ=
 github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=

--- a/go.sum
+++ b/go.sum
@@ -42,9 +42,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
-github.com/centrifuge/go-substrate-rpc-client v1.1.0/go.mod h1:GBMLH8MQs5g4FcrytcMm9uRgBnTL1LIkNTue6lUPhZU=
-github.com/centrifuge/go-substrate-rpc-client v1.1.1-0.20200428140716-e238735648d6 h1:wA8hkwP5xlNCWUxoTqLeP6gxl8olY8aedBUkfHMi2Tg=
-github.com/centrifuge/go-substrate-rpc-client v1.1.1-0.20200428140716-e238735648d6/go.mod h1:GBMLH8MQs5g4FcrytcMm9uRgBnTL1LIkNTue6lUPhZU=
+github.com/centrifuge/go-substrate-rpc-client v2.0.0-alpha.3+incompatible h1:d8hQYVrpemZ6ZN38kL1XdQtezXTwrgiVXgQg+M3Lay0=
+github.com/centrifuge/go-substrate-rpc-client v2.0.0-alpha.3+incompatible/go.mod h1:GBMLH8MQs5g4FcrytcMm9uRgBnTL1LIkNTue6lUPhZU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -136,6 +135,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mikiquantum/chainbridge-substrate-events v0.0.0-20200714203812-fb6d256611a4 h1:lT6TEOf8Og8RitN/zaFgY0qT75wIHX+3K9JUXlheZfk=
+github.com/mikiquantum/chainbridge-substrate-events v0.0.0-20200714203812-fb6d256611a4/go.mod h1:H5fNH57wn/j1oLifOnWEqYbfJZcOWzr7jZjKKrUckSQ=
 github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=

--- a/shared/substrate/submit.go
+++ b/shared/substrate/submit.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"fmt"
+	"math/big"
 	"sync"
 
 	"github.com/ChainSafe/log15"
@@ -40,9 +41,9 @@ func SubmitTx(client *Client, method Method, args ...interface{}) error {
 		BlockHash:   client.Genesis,
 		Era:         types.ExtrinsicEra{IsMortalEra: false},
 		GenesisHash: client.Genesis,
-		Nonce:       types.UCompact(acct.Nonce),
+		Nonce:       types.NewUCompactFromUInt(uint64(acct.Nonce)),
 		SpecVersion: rv.SpecVersion,
-		Tip:         0,
+		Tip:         types.NewUCompactFromUInt(0),
 	}
 	err = ext.Sign(*client.Key, o)
 	if err != nil {
@@ -98,9 +99,9 @@ func BatchSubmit(client *Client, calls []types.Call) error {
 		BlockHash:   client.Genesis,
 		Era:         types.ExtrinsicEra{IsMortalEra: false},
 		GenesisHash: client.Genesis,
-		Nonce:       types.UCompact(acct.Nonce),
+		Nonce:       types.NewUCompactFromUInt(uint64(acct.Nonce)),
 		SpecVersion: rv.SpecVersion,
-		Tip:         0,
+		Tip:         types.NewUCompactFromUInt(0),
 	}
 
 	wg := &sync.WaitGroup{}
@@ -137,7 +138,8 @@ func BatchSubmit(client *Client, calls []types.Call) error {
 			}
 		}()
 
-		o.Nonce = o.Nonce + 1
+		bigNonce := big.Int(o.Nonce)
+		o.Nonce = types.NewUCompactFromUInt(bigNonce.Uint64() + 1)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Update to latest GSRPC https://github.com/centrifuge/go-substrate-rpc-client/releases/tag/v2.0.0-alpha.3
In particular fixes UCompact type to support Big Numbers up to 536 bit (per substrate SCALE specs)
