### PR TITLE
Updates substrate go rpc for v12 metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ site/
 .env
 bridge
 keys/
+*.key
 
 # Chainbridge
 config.toml

--- a/chains/substrate/connection.go
+++ b/chains/substrate/connection.go
@@ -181,7 +181,7 @@ func (c *Connection) queryStorage(prefix, method string, arg1, arg2 []byte, resu
 
 // TODO: Add this to GSRPC
 func getConst(meta *types.Metadata, prefix, name string, res interface{}) error {
-	for _, mod := range meta.AsMetadataV11.Modules {
+	for _, mod := range meta.AsMetadataV12.Modules {
 		if string(mod.Name) == prefix {
 			for _, cons := range mod.Constants {
 				if string(cons.Name) == name {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ChainSafe/chainbridge-utils v1.0.5
 	github.com/ChainSafe/log15 v1.0.0
 	github.com/aristanetworks/goarista v0.0.0-20200609010056-95bcf8053598 // indirect
-	github.com/centrifuge/go-substrate-rpc-client v2.0.0-rc6-0+incompatible
+	github.com/centrifuge/go-substrate-rpc-client v2.0.0+incompatible
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/ethereum/go-ethereum v1.9.17
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,9 +15,7 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532025e h1:c7NSjEfp13ua566bC2KSNmyx0Cvj1cciO2klsFIQv2I=
 github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532025e/go.mod h1:H5fNH57wn/j1oLifOnWEqYbfJZcOWzr7jZjKKrUckSQ=
-github.com/ChainSafe/chainbridge-utils v1.0.3 h1:a8pa5N11uo2wzgzNV9QkSocFrbkO+HiWCiihKDnkuAg=
-github.com/ChainSafe/chainbridge-utils v1.0.3/go.mod h1:T5cOZhxdY4x0DrE0EqOnMwAPE8d4bNGqiPfN16o1rzc=
-github.com/ChainSafe/chainbridge-utils v1.0.4/go.mod h1:T5cOZhxdY4x0DrE0EqOnMwAPE8d4bNGqiPfN16o1rzc=
+github.com/ChainSafe/chainbridge-utils v1.0.5 h1:PiJyz8+Ed6/Jlq1nsQ1shY5btT1ERdaiPU8+Fg+BvZE=
 github.com/ChainSafe/chainbridge-utils v1.0.5/go.mod h1:T5cOZhxdY4x0DrE0EqOnMwAPE8d4bNGqiPfN16o1rzc=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
@@ -68,6 +66,8 @@ github.com/centrifuge/go-substrate-rpc-client v2.0.0-alpha.5+incompatible h1:QzF
 github.com/centrifuge/go-substrate-rpc-client v2.0.0-alpha.5+incompatible/go.mod h1:GBMLH8MQs5g4FcrytcMm9uRgBnTL1LIkNTue6lUPhZU=
 github.com/centrifuge/go-substrate-rpc-client v2.0.0-rc6-0+incompatible h1:+H/LOoOMiAlww9xayOEAxa4mF6Tp+AgzzJDE9pQ37D8=
 github.com/centrifuge/go-substrate-rpc-client v2.0.0-rc6-0+incompatible/go.mod h1:GBMLH8MQs5g4FcrytcMm9uRgBnTL1LIkNTue6lUPhZU=
+github.com/centrifuge/go-substrate-rpc-client v2.0.0+incompatible h1:FvPewruOgelqA/DVBdX7/Q6znUGGQ+g0ciG5tA2Fk98=
+github.com/centrifuge/go-substrate-rpc-client v2.0.0+incompatible/go.mod h1:GBMLH8MQs5g4FcrytcMm9uRgBnTL1LIkNTue6lUPhZU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/shared/substrate/events.go
+++ b/shared/substrate/events.go
@@ -146,5 +146,5 @@ type Events struct {
 	MultiAccount_MultisigApproval    []EventMultisigApproval               //nolint:stylecheck,golint
 	MultiAccount_MultisigExecuted    []EventMultisigExecuted               //nolint:stylecheck,golint
 	MultiAccount_MultisigCancelled   []EventMultisigCancelled              //nolint:stylecheck,golint
-	TreasuryReward_TreasuryMinting 	 []EventTreasuryMinting 			   //nolint:stylecheck,gol
+	TreasuryReward_TreasuryMinting 	 []EventTreasuryMinting		       //nolint:stylecheck,gol
 }

--- a/shared/substrate/events.go
+++ b/shared/substrate/events.go
@@ -117,6 +117,12 @@ type EventMultisigCancelled struct {
 	Topics    []types.Hash
 }
 
+type EventTreasuryMinting struct {
+	Phase     	types.Phase
+	Who	        types.AccountID
+	Topics    	[]types.Hash
+}
+
 type Events struct {
 	types.EventRecords
 	events.Events
@@ -140,4 +146,5 @@ type Events struct {
 	MultiAccount_MultisigApproval    []EventMultisigApproval               //nolint:stylecheck,golint
 	MultiAccount_MultisigExecuted    []EventMultisigExecuted               //nolint:stylecheck,golint
 	MultiAccount_MultisigCancelled   []EventMultisigCancelled              //nolint:stylecheck,golint
+	TreasuryReward_TreasuryMinting 	 []EventTreasuryMinting 			   //nolint:stylecheck,gol
 }


### PR DESCRIPTION
<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Updates the substrate go rpc version for substrate 2.0 and v12 metadata

#### Closes: #?
https://github.com/ChainSafe/ChainBridge/issues/535