### PR TITLE
Update utils and block timeout for health server

### DIFF
--- a/cmd/chainbridge/main.go
+++ b/cmd/chainbridge/main.go
@@ -163,9 +163,9 @@ func run(ctx *cli.Context) error {
 	c := core.NewCore(sysErr)
 
 	for _, chain := range cfg.Chains {
-		chainId, err := strconv.Atoi(chain.Id)
-		if err != nil {
-			return err
+		chainId, errr := strconv.Atoi(chain.Id)
+		if errr != nil {
+			return errr
 		}
 		chainConfig := &core.ChainConfig{
 			Name:           chain.Name,
@@ -206,7 +206,15 @@ func run(ctx *cli.Context) error {
 	// Start prometheus and health server
 	if ctx.Bool(config.MetricsFlag.Name) {
 		port := ctx.Int(config.MetricsPort.Name)
-		h := health.NewHealthServer(port, c.Registry)
+		blockTimeoutStr := os.Getenv(config.HealthBlockTimeout)
+		blockTimeout := config.DefaultBlockTimeout
+		if blockTimeoutStr != "" {
+			blockTimeout, err = strconv.ParseInt(blockTimeoutStr, 10, 0)
+			if err != nil {
+				return err
+			}
+		}
+		h := health.NewHealthServer(port, c.Registry, int(blockTimeout))
 
 		go func() {
 			http.Handle("/metrics", promhttp.Handler())

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 
 const DefaultConfigPath = "./config.json"
 const DefaultKeystorePath = "./keys"
+const DefaultBlockTimeout = int64(180) // 3 minutes
 
 type Config struct {
 	Chains       []RawChainConfig `json:"chains"`

--- a/config/flags.go
+++ b/config/flags.go
@@ -8,6 +8,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// Env vars
+var (
+	HealthBlockTimeout = "BLOCK_TIMEOUT"
+)
+
 var (
 	ConfigFileFlag = &cli.StringFlag{
 		Name:  "config",

--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -1,0 +1,47 @@
+# CLI Options
+
+## Flags
+
+### Global
+
+```
+--config value       JSON configuration file
+--verbosity value    Supports levels crit (silent) to trce (trace) (default: "info")
+--keystore value     Path to keystore directory (default: "./keys")
+--blockstore value   Specify path for blockstore
+--fresh              Disables loading from blockstore at start. Opts will still be used if specified. (default: false)
+--latest             Overrides blockstore and start block, starts from latest block (default: false)
+--metrics            Enables metric server (default: false)
+--metricsPort value  Port to serve metrics on (default: 8001)
+--testkey value      Applies a predetermined test keystore to the chains.
+--help, -h           show help (default: false)
+--version, -v        print the version (default: false)
+```
+
+### Account Management
+
+The commands can be used to manage keys in the local keystore. You can view available keys with `chainbridge accounts list`.
+
+#### `chainbridge accounts generate`
+```
+--password value  Password used to encrypt the keystore. Used with --generate, --import, or --unlock
+--sr25519         Specify account/key type as sr25519. (default: false)
+--secp256k1       Specify account/key type as secp256k1. (default: false)
+--network value   Specify the network to use for the address encoding (substrate/polkadot/centrifuge) (default: substrate)
+```
+
+#### `chainbridge accounts import`
+```
+--ethereum          Import an existing ethereum keystore, such as from geth. (default: false)
+--privateKey value  Import a hex representation of a private key into a keystore.
+--sr25519           Specify account/key type as sr25519. (default: false)
+--secp256k1         Specify account/key type as secp256k1. (default: false)
+--password value    Password used to encrypt the keystore. Used with --generate, --import, or --unlock
+--network value     Specify the network to use for the address encoding (substrate/polkadot/centrifuge) (default: substrate)
+```
+
+
+## Environment Variables
+
+- `KEYSTORE_PASSWORD`: The password to use when loading the keystore.
+- `BLOCK_TIMEOUT`: The duration (seconds) until a chain is considered "unhealthy"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532025e
-	github.com/ChainSafe/chainbridge-utils v1.0.5
+	github.com/ChainSafe/chainbridge-utils v1.0.6
 	github.com/ChainSafe/log15 v1.0.0
 	github.com/aristanetworks/goarista v0.0.0-20200609010056-95bcf8053598 // indirect
 	github.com/centrifuge/go-substrate-rpc-client v2.0.0-rc6-0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532
 github.com/ChainSafe/chainbridge-substrate-events v0.0.0-20200715141113-87198532025e/go.mod h1:H5fNH57wn/j1oLifOnWEqYbfJZcOWzr7jZjKKrUckSQ=
 github.com/ChainSafe/chainbridge-utils v1.0.5 h1:PiJyz8+Ed6/Jlq1nsQ1shY5btT1ERdaiPU8+Fg+BvZE=
 github.com/ChainSafe/chainbridge-utils v1.0.5/go.mod h1:T5cOZhxdY4x0DrE0EqOnMwAPE8d4bNGqiPfN16o1rzc=
+github.com/ChainSafe/chainbridge-utils v1.0.6 h1:DV9dNnrsU7fRG49biyRlHsPLd9Augv9lepxnP581ixM=
+github.com/ChainSafe/chainbridge-utils v1.0.6/go.mod h1:T5cOZhxdY4x0DrE0EqOnMwAPE8d4bNGqiPfN16o1rzc=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,9 @@ theme:
 nav:
   - Overview: index.md
   - Installation: installation.md
-  - Configuration: configuration.md
+  - Configuration:
+    - Overview: configuration.md
+    - CLI Options: cli-options.md
   - Specification:
       - ChainBridge: spec.md
       - Ethereum: chains/ethereum.md


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Bump to chainbridge-utils v1.0.6
- Adds env var for the block timeout for the health server
- Introduces a new page in the docs for CLI options

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #?
