### PR TITLE
Forward porting our rt4 types

### DIFF
--- a/shared/substrate/events.go
+++ b/shared/substrate/events.go
@@ -123,6 +123,52 @@ type EventTreasuryMinting struct {
 	Topics []types.Hash
 }
 
+// EventRadClaimsClaimed is emitted when RAD Tokens have been claimed
+type EventRadClaimsClaimed struct {
+	Phase  types.Phase
+	Who    types.AccountID
+	Value  types.U128
+	Topics []types.Hash
+}
+
+// EventRadClaimsRootHashStored is emitted when RootHash has been stored for the correspondent RAD Claims batch
+type EventRadClaimsRootHashStored struct {
+	Phase    types.Phase
+	RootHash types.Hash
+	Topics   []types.Hash
+}
+
+// EventNftTransferred is emitted when the ownership of the asset has been transferred to the account
+type EventNftTransferred struct {
+	Phase      types.Phase
+	RegistryId RegistryId
+	AssetId    AssetId
+	Who        types.AccountID
+	Topics     []types.Hash
+}
+
+// EventRegistryMint is emitted when successfully minting an NFT
+type EventRegistryMint struct {
+	Phase      types.Phase
+	RegistryId RegistryId
+	TokenId    TokenId
+	Topics     []types.Hash
+}
+
+// EventRegistryRegistryCreated is emitted when successfully creating a NFT registry
+type EventRegistryRegistryCreated struct {
+	Phase      types.Phase
+	RegistryId RegistryId
+	Topics     []types.Hash
+}
+
+// EventRegistryTmp is emitted only for testing
+type EventRegistryTmp struct {
+	Phase  types.Phase
+	Hash   types.Hash
+	Topics []types.Hash
+}
+
 type Events struct {
 	types.EventRecords
 	events.Events
@@ -147,4 +193,10 @@ type Events struct {
 	MultiAccount_MultisigExecuted    []EventMultisigExecuted               //nolint:stylecheck,golint
 	MultiAccount_MultisigCancelled   []EventMultisigCancelled              //nolint:stylecheck,golint
 	TreasuryReward_TreasuryMinting   []EventTreasuryMinting                //nolint:stylecheck,gol
+	Nft_Transferred                  []EventNftTransferred                 //nolint:stylecheck,golint
+	RadClaims_Claimed                []EventRadClaimsClaimed               //nolint:stylecheck,golint
+	RadClaims_RootHashStored         []EventRadClaimsRootHashStored        //nolint:stylecheck,golint
+	Registry_Mint                    []EventRegistryMint                   //nolint:stylecheck,golint
+	Registry_RegistryCreated         []EventRegistryRegistryCreated        //nolint:stylecheck,golint
+	Registry_RegistryTmp             []EventRegistryTmp                    //nolint:stylecheck,golint
 }

--- a/shared/substrate/events.go
+++ b/shared/substrate/events.go
@@ -192,7 +192,7 @@ type Events struct {
 	MultiAccount_MultisigApproval    []EventMultisigApproval               //nolint:stylecheck,golint
 	MultiAccount_MultisigExecuted    []EventMultisigExecuted               //nolint:stylecheck,golint
 	MultiAccount_MultisigCancelled   []EventMultisigCancelled              //nolint:stylecheck,golint
-	TreasuryReward_TreasuryMinting   []EventTreasuryMinting                //nolint:stylecheck,gol
+	TreasuryReward_TreasuryMinting   []EventTreasuryMinting                //nolint:stylecheck,golint
 	Nft_Transferred                  []EventNftTransferred                 //nolint:stylecheck,golint
 	RadClaims_Claimed                []EventRadClaimsClaimed               //nolint:stylecheck,golint
 	RadClaims_RootHashStored         []EventRadClaimsRootHashStored        //nolint:stylecheck,golint

--- a/shared/substrate/types.go
+++ b/shared/substrate/types.go
@@ -14,3 +14,11 @@ type Erc721Token struct {
 	Id       types.U256
 	Metadata types.Bytes
 }
+
+type RegistryId types.H160
+type TokenId types.U256
+
+type AssetId struct {
+	RegistryId RegistryId
+	TokenId    TokenId
+}


### PR DESCRIPTION
Since we are using our own fork of the ChainBridge due to the fact that Centrifuge is still in RC6, wanted to push this so we do not forget about it when we come back to the main one.

Types and Events added are backwards compatible, will only be used if present in the listened chain.
 
