### PR TITLE
Wait for block confirmations when executing proposal

### DIFF
--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -55,7 +55,7 @@ type Connection interface {
 	Client() *ethclient.Client
 	EnsureHasBytecode(address common.Address) error
 	LatestBlock() (*big.Int, error)
-	WaitForBlock(block *big.Int) error
+	WaitForBlock(block *big.Int, delay *big.Int) error
 	Close()
 }
 

--- a/chains/ethereum/test_utils_test.go
+++ b/chains/ethereum/test_utils_test.go
@@ -49,7 +49,7 @@ func createConfig(name string, startBlock *big.Int, contracts *utils.DeployedCon
 		gasMultiplier:          big.NewFloat(DefaultGasMultiplier),
 		http:                   false,
 		startBlock:             startBlock,
-		blockConfirmations:     big.NewInt(0),
+		blockConfirmations:     big.NewInt(3),
 	}
 
 	if contracts != nil {

--- a/chains/ethereum/writer_methods.go
+++ b/chains/ethereum/writer_methods.go
@@ -170,7 +170,7 @@ func (w *writer) watchThenExecute(m msg.Message, data []byte, dataHash [32]byte,
 		default:
 			// watch for the lastest block, retry up to BlockRetryLimit times
 			for waitRetrys := 0; waitRetrys < BlockRetryLimit; waitRetrys++ {
-				err := w.conn.WaitForBlock(latestBlock)
+				err := w.conn.WaitForBlock(latestBlock, w.cfg.blockConfirmations)
 				if err != nil {
 					w.log.Error("Waiting for block failed", "err", err)
 					// Exit if retries exceeded

--- a/connections/ethereum/connection.go
+++ b/connections/ethereum/connection.go
@@ -193,8 +193,9 @@ func (c *Connection) EnsureHasBytecode(addr ethcommon.Address) error {
 	return nil
 }
 
-// WaitForBlock will poll for the block number until the current block is equal or greater than
-func (c *Connection) WaitForBlock(block *big.Int) error {
+// WaitForBlock will poll for the block number until the current block is equal or greater.
+// If delay is provided it will wait until currBlock - delay = targetBlock
+func (c *Connection) WaitForBlock(targetBlock *big.Int, delay *big.Int) error {
 	for {
 		select {
 		case <-c.stop:
@@ -205,11 +206,15 @@ func (c *Connection) WaitForBlock(block *big.Int) error {
 				return err
 			}
 
+			if delay != nil {
+				currBlock.Sub(currBlock, delay)
+			}
+
 			// Equal or greater than target
-			if currBlock.Cmp(block) >= 0 {
+			if currBlock.Cmp(targetBlock) >= 0 {
 				return nil
 			}
-			c.log.Trace("Block not ready, waiting", "target", block, "current", currBlock)
+			c.log.Trace("Block not ready, waiting", "target", targetBlock, "current", currBlock, "delay", delay)
 			time.Sleep(BlockRetryInterval)
 			continue
 		}

--- a/e2e/ethereum/ethereum.go
+++ b/e2e/ethereum/ethereum.go
@@ -70,6 +70,7 @@ func CreateConfig(key string, chain msg.ChainId, contracts *utils.DeployedContra
 			"erc20Handler":   contracts.ERC20HandlerAddress.String(),
 			"erc721Handler":  contracts.ERC721HandlerAddress.String(),
 			"genericHandler": contracts.GenericHandlerAddress.String(),
+			"blockConfirmations": "3",
 		},
 	}
 }

--- a/e2e/ethereum/ethereum.go
+++ b/e2e/ethereum/ethereum.go
@@ -66,10 +66,10 @@ func CreateConfig(key string, chain msg.ChainId, contracts *utils.DeployedContra
 		FreshStart:     true,
 		BlockstorePath: os.TempDir(),
 		Opts: map[string]string{
-			"bridge":         contracts.BridgeAddress.String(),
-			"erc20Handler":   contracts.ERC20HandlerAddress.String(),
-			"erc721Handler":  contracts.ERC721HandlerAddress.String(),
-			"genericHandler": contracts.GenericHandlerAddress.String(),
+			"bridge":             contracts.BridgeAddress.String(),
+			"erc20Handler":       contracts.ERC20HandlerAddress.String(),
+			"erc721Handler":      contracts.ERC721HandlerAddress.String(),
+			"genericHandler":     contracts.GenericHandlerAddress.String(),
 			"blockConfirmations": "3",
 		},
 	}


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Adds delay to `connection.WaitForBlock`
- Use `blockConfirmations` as a delay when waiting for proposal votes

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
#### Closes: #563 
