### PR TITLE
Use TransactionVersion fetched from runtime metadata

### DIFF
--- a/chains/substrate/connection.go
+++ b/chains/substrate/connection.go
@@ -122,7 +122,7 @@ func (c *Connection) SubmitTx(method utils.Method, args ...interface{}) error {
 		Nonce:              types.NewUCompactFromUInt(uint64(c.nonce)),
 		SpecVersion:        rv.SpecVersion,
 		Tip:                types.NewUCompactFromUInt(0),
-		TransactionVersion: 1,
+		TransactionVersion: rv.TransactionVersion,
 	}
 
 	err = ext.Sign(*c.key, o)

--- a/shared/substrate/submit.go
+++ b/shared/substrate/submit.go
@@ -44,7 +44,7 @@ func SubmitTx(client *Client, method Method, args ...interface{}) error {
 		Nonce:              types.NewUCompactFromUInt(uint64(acct.Nonce)),
 		SpecVersion:        rv.SpecVersion,
 		Tip:                types.NewUCompactFromUInt(0),
-		TransactionVersion: 1,
+		TransactionVersion: rv.TransactionVersion,
 	}
 	err = ext.Sign(*client.Key, o)
 	if err != nil {
@@ -103,7 +103,7 @@ func BatchSubmit(client *Client, calls []types.Call) error {
 		Nonce:              types.NewUCompactFromUInt(uint64(acct.Nonce)),
 		SpecVersion:        rv.SpecVersion,
 		Tip:                types.NewUCompactFromUInt(0),
-		TransactionVersion: 1,
+		TransactionVersion: rv.TransactionVersion,
 	}
 
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
## Description
Use TransactionVersion fetched from runtime metadata instead of hardcode with "1".
Different chain may have different transaction version defiend in runtime, it's better to 
assign dynamically. A reference can be found in [GSRPC](https://github.com/centrifuge/go-substrate-rpc-client/blob/c38f4745089beae0d8bb8cc4aa4b364c452b81f8/main_test.go#L249)

## Related Issue Or Context

If hard code with "1", when submit extrinsic to chain whose runtime version is not "1" would 
got error: 

- With ```"useExtendedCall": "true"``` in config.json

```sh
Failed to execute extrinsic              chain=sub err="submission of extrinsic failed: Invalid Transaction"
```

- Without ```"useExtendedCall": "true"``` in config.json

```sh
EROR[04-25|11:13:54] Failed to execute extrinsic              chain=sub err="submission of extrinsic failed: Verification Error: Runtime error: Execution failed: ApiError(FailedToConvertParameter { function: \"validate_transaction\", parameter: \"tx\", error: Error { cause: Some(Error { cause: Some(Error { cause: Some(Error { cause: Some(Error { cause: None, desc: \"Not enough data to fill buffer\" }), desc: \"Could not decode `Call::transfer.2`\" }), desc: \"Could not decode `Call::BridgeTransfer.0`\" }), desc: \"Could not decode `Call::acknowledge_proposal.3`\" }), desc: \"Could not decode `Call::ChainBridge.0`\" } })"
```

## How Has This Been Tested? Testing details.

Run a substrate chain which build with substrate v3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ x ] I have ensured that all the checks are passing and green, I've signed the CLA bot
