### PR TITLE
Optional handlers

### DIFF
--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -117,6 +117,7 @@ func InitializeChain(chainCfg *core.ChainConfig, logger log15.Logger, sysErr cha
 	if err != nil {
 		return nil, err
 	}
+
 	if cfg.erc20HandlerContract == utils.ZeroAddress {
 		err = nil
 	} else {
@@ -125,6 +126,7 @@ func InitializeChain(chainCfg *core.ChainConfig, logger log15.Logger, sysErr cha
 	if err != nil {
 		return nil, err
 	}
+
 	if cfg.genericHandlerContract == utils.ZeroAddress {
 		err = nil
 	} else {

--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -118,22 +118,18 @@ func InitializeChain(chainCfg *core.ChainConfig, logger log15.Logger, sysErr cha
 		return nil, err
 	}
 
-	if cfg.erc20HandlerContract == utils.ZeroAddress {
-		err = nil
-	} else {
+	if cfg.erc20HandlerContract != utils.ZeroAddress {
 		err = conn.EnsureHasBytecode(cfg.erc20HandlerContract)
-	}
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	if cfg.genericHandlerContract == utils.ZeroAddress {
-		err = nil
-	} else {
+	if cfg.genericHandlerContract != utils.ZeroAddress {
 		err = conn.EnsureHasBytecode(cfg.genericHandlerContract)
-	}
-	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bridgeContract, err := bridge.NewBridge(cfg.bridgeContract, conn.Client())

--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -29,6 +29,7 @@ import (
 	erc721Handler "github.com/ChainSafe/ChainBridge/bindings/ERC721Handler"
 	"github.com/ChainSafe/ChainBridge/bindings/GenericHandler"
 	connection "github.com/ChainSafe/ChainBridge/connections/ethereum"
+	utils "github.com/ChainSafe/ChainBridge/shared/ethereum"
 	"github.com/ChainSafe/chainbridge-utils/blockstore"
 	"github.com/ChainSafe/chainbridge-utils/core"
 	"github.com/ChainSafe/chainbridge-utils/crypto/secp256k1"
@@ -116,11 +117,19 @@ func InitializeChain(chainCfg *core.ChainConfig, logger log15.Logger, sysErr cha
 	if err != nil {
 		return nil, err
 	}
-	err = conn.EnsureHasBytecode(cfg.erc20HandlerContract)
+	if cfg.erc20HandlerContract == utils.ZeroAddress {
+		err = nil
+	} else {
+		err = conn.EnsureHasBytecode(cfg.erc20HandlerContract)
+	}
 	if err != nil {
 		return nil, err
 	}
-	err = conn.EnsureHasBytecode(cfg.genericHandlerContract)
+	if cfg.genericHandlerContract == utils.ZeroAddress {
+		err = nil
+	} else {
+		err = conn.EnsureHasBytecode(cfg.genericHandlerContract)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/chains/ethereum/config.go
+++ b/chains/ethereum/config.go
@@ -91,14 +91,20 @@ func parseChainConfig(chainCfg *core.ChainConfig) (*Config, error) {
 		return nil, fmt.Errorf("must provide opts.bridge field for ethereum config")
 	}
 
-	config.erc20HandlerContract = common.HexToAddress(chainCfg.Opts[Erc20HandlerOpt])
-	delete(chainCfg.Opts, Erc20HandlerOpt)
+	if contract, ok := chainCfg.Opts[Erc20HandlerOpt]; ok {
+		config.erc20HandlerContract = common.HexToAddress(contract)
+		delete(chainCfg.Opts, Erc20HandlerOpt)
+	}
 
-	config.erc721HandlerContract = common.HexToAddress(chainCfg.Opts[Erc721HandlerOpt])
-	delete(chainCfg.Opts, Erc721HandlerOpt)
+	if contract, ok := chainCfg.Opts[Erc721HandlerOpt]; ok {
+		config.erc20HandlerContract = common.HexToAddress(contract)
+		delete(chainCfg.Opts, Erc721HandlerOpt)
+	}
 
-	config.genericHandlerContract = common.HexToAddress(chainCfg.Opts[GenericHandlerOpt])
-	delete(chainCfg.Opts, GenericHandlerOpt)
+	if contract, ok := chainCfg.Opts[GenericHandlerOpt]; ok {
+		config.erc20HandlerContract = common.HexToAddress(contract)
+		delete(chainCfg.Opts, GenericHandlerOpt)
+	}
 
 	if gasPrice, ok := chainCfg.Opts[MaxGasPriceOpt]; ok {
 		price := big.NewInt(0)

--- a/chains/ethereum/config.go
+++ b/chains/ethereum/config.go
@@ -97,12 +97,12 @@ func parseChainConfig(chainCfg *core.ChainConfig) (*Config, error) {
 	}
 
 	if contract, ok := chainCfg.Opts[Erc721HandlerOpt]; ok {
-		config.erc20HandlerContract = common.HexToAddress(contract)
+		config.erc721HandlerContract = common.HexToAddress(contract)
 		delete(chainCfg.Opts, Erc721HandlerOpt)
 	}
 
 	if contract, ok := chainCfg.Opts[GenericHandlerOpt]; ok {
-		config.erc20HandlerContract = common.HexToAddress(contract)
+		config.genericHandlerContract = common.HexToAddress(contract)
 		delete(chainCfg.Opts, GenericHandlerOpt)
 	}
 

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -4,16 +4,11 @@
 package ethereum
 
 import (
-	utils "github.com/ChainSafe/ChainBridge/shared/ethereum"
 	"github.com/ChainSafe/chainbridge-utils/msg"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 func (l *listener) handleErc20DepositedEvent(destId msg.ChainId, nonce msg.Nonce) (msg.Message, error) {
-	if l.cfg.erc20HandlerContract == utils.ZeroAddress {
-		l.log.Warn("You are attempting to perform an ERC20 transfer without a deployed handler")
-	}
-
 	l.log.Info("Handling fungible deposit event", "dest", destId, "nonce", nonce)
 
 	record, err := l.erc20HandlerContract.GetDepositRecord(&bind.CallOpts{From: l.conn.Keypair().CommonAddress()}, uint64(nonce), uint8(destId))
@@ -33,10 +28,6 @@ func (l *listener) handleErc20DepositedEvent(destId msg.ChainId, nonce msg.Nonce
 }
 
 func (l *listener) handleErc721DepositedEvent(destId msg.ChainId, nonce msg.Nonce) (msg.Message, error) {
-	if l.cfg.erc20HandlerContract == utils.ZeroAddress {
-		l.log.Warn("You are attempting to perform an ERC721 transfer without a deployed handler")
-	}
-
 	l.log.Info("Handling nonfungible deposit event")
 
 	record, err := l.erc721HandlerContract.GetDepositRecord(&bind.CallOpts{From: l.conn.Keypair().CommonAddress()}, uint64(nonce), uint8(destId))
@@ -57,10 +48,6 @@ func (l *listener) handleErc721DepositedEvent(destId msg.ChainId, nonce msg.Nonc
 }
 
 func (l *listener) handleGenericDepositedEvent(destId msg.ChainId, nonce msg.Nonce) (msg.Message, error) {
-	if l.cfg.erc20HandlerContract == utils.ZeroAddress {
-		l.log.Warn("You are attempting to perform a generic transfer without a deployed handler")
-	}
-
 	l.log.Info("Handling generic deposit event")
 
 	record, err := l.genericHandlerContract.GetDepositRecord(&bind.CallOpts{From: l.conn.Keypair().CommonAddress()}, uint64(nonce), uint8(destId))

--- a/chains/ethereum/events.go
+++ b/chains/ethereum/events.go
@@ -4,11 +4,16 @@
 package ethereum
 
 import (
+	utils "github.com/ChainSafe/ChainBridge/shared/ethereum"
 	"github.com/ChainSafe/chainbridge-utils/msg"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 func (l *listener) handleErc20DepositedEvent(destId msg.ChainId, nonce msg.Nonce) (msg.Message, error) {
+	if l.cfg.erc20HandlerContract == utils.ZeroAddress {
+		l.log.Warn("You are attempting to perform an ERC20 transfer without a deployed handler")
+	}
+
 	l.log.Info("Handling fungible deposit event", "dest", destId, "nonce", nonce)
 
 	record, err := l.erc20HandlerContract.GetDepositRecord(&bind.CallOpts{From: l.conn.Keypair().CommonAddress()}, uint64(nonce), uint8(destId))
@@ -28,6 +33,10 @@ func (l *listener) handleErc20DepositedEvent(destId msg.ChainId, nonce msg.Nonce
 }
 
 func (l *listener) handleErc721DepositedEvent(destId msg.ChainId, nonce msg.Nonce) (msg.Message, error) {
+	if l.cfg.erc20HandlerContract == utils.ZeroAddress {
+		l.log.Warn("You are attempting to perform an ERC721 transfer without a deployed handler")
+	}
+
 	l.log.Info("Handling nonfungible deposit event")
 
 	record, err := l.erc721HandlerContract.GetDepositRecord(&bind.CallOpts{From: l.conn.Keypair().CommonAddress()}, uint64(nonce), uint8(destId))
@@ -48,6 +57,10 @@ func (l *listener) handleErc721DepositedEvent(destId msg.ChainId, nonce msg.Nonc
 }
 
 func (l *listener) handleGenericDepositedEvent(destId msg.ChainId, nonce msg.Nonce) (msg.Message, error) {
+	if l.cfg.erc20HandlerContract == utils.ZeroAddress {
+		l.log.Warn("You are attempting to perform a generic transfer without a deployed handler")
+	}
+
 	l.log.Info("Handling generic deposit event")
 
 	record, err := l.genericHandlerContract.GetDepositRecord(&bind.CallOpts{From: l.conn.Keypair().CommonAddress()}, uint64(nonce), uint8(destId))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Made conditionals on parsing the config file for the handlers, as well as a conditional for when checking whether the contract from the config file has deployed bytecode. 

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

This will allow for being able to specify only certain handlers in the config, and will not require all of them. I noticed also that the ERC20Handler and the GenericHandler are being checked for bytecode, but not ERC721Handler. Should I add in the same bytecode check (now only when the ERC721Handler is within the config). 

Closes: #530 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

There are existing config tests including whether or not there was only a single contract specified in the config. These all passed.

I was successfully able to run ChainBridge with missing handlers from the config and without those respective handlers deployed. Previously you would not be able to run the bridge resulting in this error:
```
INFO[05-20|14:03:25] Starting ChainBridge... 
INFO[05-20|14:03:25] Connecting to ethereum chain...          chain=eth url=ws://localhost:8545
EROR[05-20|14:03:25] no bytecode found at 0x0000000000000000000000000000000000000000 
```

For the running locally guide, one may run into issues with the contracts simply due to the deterministic nature of `cb-sol-cli` deploys but it runs correctly with the correct contracts specified.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in chainbridge-docs.
- [X] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
