### PR TITLE
More verbose failed tx logging

### DIFF
--- a/chains/ethereum/writer_methods.go
+++ b/chains/ethereum/writer_methods.go
@@ -274,7 +274,7 @@ func (w *writer) voteProposal(m msg.Message, dataHash [32]byte) {
 				w.log.Debug("Nonce too low, will retry")
 				time.Sleep(TxRetryInterval)
 			} else {
-				w.log.Warn("Voting failed", "source", m.Source, "dest", m.Destination, "depositNonce", m.DepositNonce, "err", err)
+				w.log.Warn("Voting failed", "source", m.Source, "dest", m.Destination, "depositNonce", m.DepositNonce, "gas", tx.Gas(), "gasPrice", tx.GasPrice().String(), "err", err)
 				time.Sleep(TxRetryInterval)
 			}
 
@@ -318,7 +318,7 @@ func (w *writer) executeProposal(m msg.Message, data []byte, dataHash [32]byte) 
 				w.log.Error("Nonce too low, will retry")
 				time.Sleep(TxRetryInterval)
 			} else {
-				w.log.Warn("Execution failed, proposal may already be complete", "err", err)
+				w.log.Warn("Execution failed, proposal may already be complete", "gas", tx.Gas(), "gasPrice", tx.GasPrice().String(), "err", err)
 				time.Sleep(TxRetryInterval)
 			}
 

--- a/chains/ethereum/writer_methods.go
+++ b/chains/ethereum/writer_methods.go
@@ -254,6 +254,10 @@ func (w *writer) voteProposal(m msg.Message, dataHash [32]byte) {
 				w.log.Error("Failed to update tx opts", "err", err)
 				continue
 			}
+			// These store the gas limit and price before a transaction is sent for logging in case of a failure
+			// This is necessary as tx will be nil in the case of an error when sending VoteProposal()
+			gasLimit := w.conn.Opts().GasLimit
+			gasPrice := w.conn.Opts().GasPrice
 
 			tx, err := w.bridgeContract.VoteProposal(
 				w.conn.Opts(),
@@ -274,7 +278,7 @@ func (w *writer) voteProposal(m msg.Message, dataHash [32]byte) {
 				w.log.Debug("Nonce too low, will retry")
 				time.Sleep(TxRetryInterval)
 			} else {
-				w.log.Warn("Voting failed", "source", m.Source, "dest", m.Destination, "depositNonce", m.DepositNonce, "gas", tx.Gas(), "gasPrice", tx.GasPrice().String(), "err", err)
+				w.log.Warn("Voting failed", "source", m.Source, "dest", m.Destination, "depositNonce", m.DepositNonce, "gasLimit", gasLimit, "gasPrice", gasPrice, "err", err)
 				time.Sleep(TxRetryInterval)
 			}
 
@@ -301,6 +305,10 @@ func (w *writer) executeProposal(m msg.Message, data []byte, dataHash [32]byte) 
 				w.log.Error("Failed to update nonce", "err", err)
 				return
 			}
+			// These store the gas limit and price before a transaction is sent for logging in case of a failure
+			// This is necessary as tx will be nil in the case of an error when sending VoteProposal()
+			gasLimit := w.conn.Opts().GasLimit
+			gasPrice := w.conn.Opts().GasPrice
 
 			tx, err := w.bridgeContract.ExecuteProposal(
 				w.conn.Opts(),
@@ -318,7 +326,7 @@ func (w *writer) executeProposal(m msg.Message, data []byte, dataHash [32]byte) 
 				w.log.Error("Nonce too low, will retry")
 				time.Sleep(TxRetryInterval)
 			} else {
-				w.log.Warn("Execution failed, proposal may already be complete", "gas", tx.Gas(), "gasPrice", tx.GasPrice().String(), "err", err)
+				w.log.Warn("Execution failed, proposal may already be complete", "gasLimit", gasLimit, "gasPrice", gasPrice, "err", err)
 				time.Sleep(TxRetryInterval)
 			}
 

--- a/chains/ethereum/writer_methods.go
+++ b/chains/ethereum/writer_methods.go
@@ -255,7 +255,9 @@ func (w *writer) voteProposal(m msg.Message, dataHash [32]byte) {
 				continue
 			}
 			// These store the gas limit and price before a transaction is sent for logging in case of a failure
-			// This is necessary as tx will be nil in the case of an error when sending VoteProposal()
+			// This declaration is necessary as tx will be nil in the case of an error when sending VoteProposal()
+			// We must also declare variables instead of using w.conn.Opts() directly as the opts are currently locked
+			// here but for all the logging after line 272 the w.conn.Opts() is unlocked and could be changed by another process
 			gasLimit := w.conn.Opts().GasLimit
 			gasPrice := w.conn.Opts().GasPrice
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I added two fields gasLimit and gasPrice to the else condition of when error checking `w.bridgeContract.VoteProposal` or `w.bridgeContract.ExecuteProposal`. I added two lines where I stored the gasLimit and gasPrice before the actual contract call. 

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Storing the gasLimit and gasPrice before the call is necessary as a failed tx will return nil when `w.bridgeContract.VoteProposal` or `w.bridgeContract.ExecuteProposal` is called. They are also stored while the opts for the transaction are locked. We need this in order to maintain consistency as another goroutine could change the opts under `w.conn.Opts()` if we were to call Opts after the unlock is done.   

Closes: #578 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I'm able to successfully call and view the result of `w.conn.Opts().GasLimit` and `w.conn.Opts().GasPrice`. The error checking by geth made it challenging to force a failed tx locally. I messed around with both the price and limit in an attempt to force a failure. I'm confident this would work but would like to see it show in the logs so I am still looking how I can cause a failure.

Currently still testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
