### PR TITLE
Use max gas price from config for TX sending when BaseFee is above maxGasPrice

### DIFF
--- a/connections/ethereum/connection.go
+++ b/connections/ethereum/connection.go
@@ -171,7 +171,7 @@ func (c *Connection) EstimateGasLondon(ctx context.Context, baseFee *big.Int) (*
 
 	if c.maxGasPrice.Cmp(baseFee) < 0 {
 		maxPriorityFeePerGas = big.NewInt(1)
-		maxFeePerGas = new(big.Int).Add(baseFee, maxPriorityFeePerGas)
+		maxFeePerGas = new(big.Int).Add(c.maxGasPrice, maxPriorityFeePerGas)
 		return maxPriorityFeePerGas, maxFeePerGas, nil
 	}
 

--- a/connections/ethereum/connection_test.go
+++ b/connections/ethereum/connection_test.go
@@ -15,7 +15,7 @@ import (
 	ethcmn "github.com/ethereum/go-ethereum/common"
 )
 
-var TestEndpoint = "ws://localhost:5000"
+var TestEndpoint = "ws://localhost:8545"
 var AliceKp = keystore.TestKeyRing.EthereumKeys[keystore.AliceKey]
 var GasLimit = big.NewInt(ethutils.DefaultGasLimit)
 var MaxGasPrice = big.NewInt(ethutils.DefaultMaxGasPrice)

--- a/connections/ethereum/connection_test.go
+++ b/connections/ethereum/connection_test.go
@@ -15,7 +15,7 @@ import (
 	ethcmn "github.com/ethereum/go-ethereum/common"
 )
 
-var TestEndpoint = "ws://localhost:8545"
+var TestEndpoint = "ws://localhost:5000"
 var AliceKp = keystore.TestKeyRing.EthereumKeys[keystore.AliceKey]
 var GasLimit = big.NewInt(ethutils.DefaultGasLimit)
 var MaxGasPrice = big.NewInt(ethutils.DefaultMaxGasPrice)
@@ -186,7 +186,7 @@ func TestConnection_EstimateGasLondonMin(t *testing.T) {
 		}
 
 		maxPriorityFeePerGas := big.NewInt(1)
-		maxFeePerGas := new(big.Int).Add(head.BaseFee, maxPriorityFeePerGas)
+		maxFeePerGas := new(big.Int).Add(maxGasPrice, maxPriorityFeePerGas)
 
 		if suggestedGasTip.Cmp(maxPriorityFeePerGas) != 0 {
 			t.Fatalf("Gas tip cap should be equal to 1. Suggested: %s Max Tip: %s", suggestedGasTip.String(), maxPriorityFeePerGas)

--- a/connections/ethereum/connection_test.go
+++ b/connections/ethereum/connection_test.go
@@ -100,7 +100,7 @@ func TestConnection_SafeEstimateGasMax(t *testing.T) {
 
 func TestConnection_EstimateGasLondon(t *testing.T) {
 	// Set TestEndpoint to Goerli endpoint when testing as the current Github CI doesn't use the London version of geth
-	// Goerli commonly has a base fee of 7 gwei with maxPriorityFeePerGas of 4.999999993 gwei
+	// Goerli commonly has a base fee of 7 wei with maxPriorityFeePerGas of 4.999999993 gwei
 	maxGasPrice := big.NewInt(100000000000)
 	conn := NewConnection(TestEndpoint, false, AliceKp, log15.Root(), GasLimit, maxGasPrice, GasMultipler, "", "")
 	err := conn.Connect()
@@ -129,7 +129,7 @@ func TestConnection_EstimateGasLondon(t *testing.T) {
 
 func TestConnection_EstimateGasLondonMax(t *testing.T) {
 	// Set TestEndpoint to Goerli endpoint when testing as the current Github CI doesn't use the London version of geth
-	// Goerli commonly has a base fee of 7 gwei with maxPriorityFeePerGas of 4.999999993 gwei
+	// Goerli commonly has a base fee of 7 wei with maxPriorityFeePerGas of 4.999999993 gwei
 	maxGasPrice := big.NewInt(100)
 	conn := NewConnection(TestEndpoint, false, AliceKp, log15.Root(), GasLimit, maxGasPrice, GasMultipler, "", "")
 	err := conn.Connect()
@@ -164,7 +164,7 @@ func TestConnection_EstimateGasLondonMax(t *testing.T) {
 
 func TestConnection_EstimateGasLondonMin(t *testing.T) {
 	// Set TestEndpoint to Goerli endpoint when testing as the current Github CI doesn't use the London version of geth
-	// Goerli commonly has a base fee of 7 gwei with maxPriorityFeePerGas of 4.999999993 gwei
+	// Goerli commonly has a base fee of 7 wei with maxPriorityFeePerGas of 4.999999993 gwei
 	maxGasPrice := big.NewInt(1)
 	conn := NewConnection(TestEndpoint, false, AliceKp, log15.Root(), GasLimit, maxGasPrice, GasMultipler, "", "")
 	err := conn.Connect()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

With the current logic we send with the current base fee even if the specified max price is below the base fee. We can change this to instead just specify the maxFeePerGas to be the maxGasPrice + 1 gwei for the priority fee, rather than how it is now with baseFee + 1 gwei. The tx will then hang in the pending state until gas goes down.

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #697 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in chainbridge-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
